### PR TITLE
Update command line arguments for upcoming 0.2 player release.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -993,10 +993,6 @@ void MainWindow::on_action_Play_Test_triggered()
 
 void MainWindow::runHere(int map_id, int x, int y)
 {
-    std::stringstream ss;
-    ss << std::setfill('0')
-       << std::setw(4)
-       << map_id;
     DialogRunGame dlg(this);
     QStringList commands;
     commands << "--test-play";
@@ -1005,9 +1001,9 @@ void MainWindow::runHere(int map_id, int x, int y)
     if (!ui->action_Full_Screen->isChecked())
         commands << "--window";
     commands << "--new-game";
-    commands << "--map-id";
-    commands << QString("%1").arg(QString::fromStdString(ss.str()));
-    commands << "--position";
+    commands << "--start-map-id";
+    commands << QString("%1").arg(map_id);
+    commands << "--start-position";
     commands << QString("%1").arg(x);
     commands << QString("%1").arg(y);
     //TODO: add auto toogle.


### PR DESCRIPTION
There are some minor changes to the command line in Player 0.2:

--map-id changed to --start-map-id
--position changed to --start-position

Padding map_id is not needed, Player does this.
Instead of using sstream you can use QString::arg(map_id, 4, '0') btw.
