### PR TITLE
Update gitignore with extra files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@
 /release
 Makefile.Debug
 Makefile.Release
+.qmake.stash
 /libs/liblcf
 /.project
 /bin/templates/Player.exe
+/bin/*.app
 /bin/*.dll
 /bin/*.exe
 /bin/*.manifest


### PR DESCRIPTION
In this PR I added two new ignored files: `*.app` directories (aka executables on OS X), and a cache file QMake automatically generated (`.qmake.stash`).
