### PR TITLE
Map editor: Fix zoom function

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -824,13 +824,13 @@ void MainWindow::on_actionLayerEvents_triggered()
 
 void MainWindow::on_actionZoomIn_triggered()
 {
-	if (static_cast<double>(currentScene()->scale()) != 2.0)
+	if (static_cast<double>(currentScene()->scale()) < 8.0)
 		currentScene()->setScale(currentScene()->scale()*2);
 }
 
 void MainWindow::on_actionZoomOut_triggered()
 {
-	if (static_cast<double>(currentScene()->scale()) != 0.25)
+	if (static_cast<double>(currentScene()->scale()) > 0.125)
 		currentScene()->setScale(currentScene()->scale()/2);
 }
 

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -478,7 +478,7 @@
     <string>Zoom 100%</string>
    </property>
    <property name="statusTip">
-    <string>Scale 200%</string>
+    <string>Zoom 100%</string>
    </property>
   </action>
   <action name="actionZoomIn">
@@ -489,7 +489,7 @@
     <string>Zoom In</string>
    </property>
    <property name="statusTip">
-    <string>Scale 100%</string>
+    <string>Zoom In</string>
    </property>
    <property name="shortcut">
     <string>+</string>
@@ -503,7 +503,7 @@
     <string>Zoom Out</string>
    </property>
    <property name="statusTip">
-    <string>Scale 50%</string>
+    <string>Zoom Out</string>
    </property>
    <property name="shortcut">
     <string>-</string>

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -228,20 +228,35 @@ void MapScene::redrawMap()
 		return;
 	core().LoadChipset(m_map->chipset_id);
 	core().setCurrentMapEvents(mapEvents());
-	s_tileSize =core().tileSize() *static_cast<int>(m_scale);
+	s_tileSize = core().tileSize() * static_cast<double>(m_scale);
 	redrawLayer(Core::LOWER);
 	redrawLayer(Core::UPPER);
 }
 
 void MapScene::setScale(float scale)
 {
+	float old_scale = m_scale;
+	int map_x = m_view->horizontalScrollBar()->value();
+	int map_y = m_view->verticalScrollBar()->value();
+
 	m_scale = scale;
-	m_lines->setScale(static_cast<int>(m_scale));
-	m_selectionTile->setScale(static_cast<int>(m_scale));
+	m_lines->setScale(static_cast<double>(m_scale));
+	m_selectionTile->setScale(static_cast<double>(m_scale));
 	this->setSceneRect(0,
-					   0,
-					   m_map->width * core().tileSize() * static_cast<int>(m_scale),
-					   m_map->height * core().tileSize() * static_cast<int>(m_scale));
+		0,
+		m_map->width * core().tileSize() * static_cast<double>(m_scale),
+		m_map->height * core().tileSize() * static_cast<double>(m_scale));
+
+	if (m_view->horizontalScrollBar()->isVisible()) {
+		m_view->horizontalScrollBar()->setValue((map_x + m_view->horizontalScrollBar()->pageStep() / 2.0) * m_scale / old_scale - m_view->horizontalScrollBar()->pageStep() / 2.0);
+	} else {
+		m_view->horizontalScrollBar()->setValue(m_view->horizontalScrollBar()->maximum() / 2.0);
+	}
+	if (m_view->verticalScrollBar()->isVisible()) {
+		m_view->verticalScrollBar()->setValue((map_y + m_view->verticalScrollBar()->pageStep() / 2.0) * m_scale / old_scale - m_view->verticalScrollBar()->pageStep() / 2.0);
+	} else {
+		m_view->verticalScrollBar()->setValue(m_view->verticalScrollBar()->maximum() / 2.0);
+	}
 	redrawMap();
 }
 
@@ -440,7 +455,7 @@ void MapScene::on_view_V_Scroll()
 		return;
 	if (m_view->verticalScrollBar()->isVisible())
 	{
-		n_mapInfo.scrollbar_y = m_view->verticalScrollBar()->value() / static_cast<int>(m_scale);
+		n_mapInfo.scrollbar_y = m_view->verticalScrollBar()->value() / static_cast<double>(m_scale);
 	}
 	m_userInteraction = false;
 }
@@ -451,7 +466,7 @@ void MapScene::on_view_H_Scroll()
 		return;
 	if (m_view->horizontalScrollBar()->isVisible())
 	{
-		n_mapInfo.scrollbar_x = m_view->horizontalScrollBar()->value() / static_cast<int>(m_scale);
+		n_mapInfo.scrollbar_x = m_view->horizontalScrollBar()->value() / static_cast<double>(m_scale);
 	}
 	m_userInteraction = false;
 }
@@ -471,12 +486,12 @@ void MapScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
 			lst_y = cur_y;
 			m_eventMenu->popup(event->screenPos());
 		}
-		if (core().tool() == Core::ZOOM && static_cast<double>(m_scale) > 0.25)
+		if (core().tool() == Core::ZOOM && static_cast<double>(m_scale) > 0.125)
 			setScale(m_scale/2);
 	}
 	if (event->button() == Qt::LeftButton)
 	{
-		if (core().tool() == Core::ZOOM && static_cast<double>(m_scale) < 2.0) // Zoom
+		if (core().tool() == Core::ZOOM && static_cast<double>(m_scale) < 8.0) // Zoom
 			setScale(m_scale*2);
 		else if (core().layer() == Core::EVENT) // Select tile
 		{


### PR DESCRIPTION
This PR makes the editor no longer crash if the zoom level is set below 100%. Moreover the minimum zoom level will be set from 25% to 12.5% and the maximum zoom level will be set from 200% to 800%.

Fixes: #145