### PR TITLE
Map management fixes

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1057,7 +1057,7 @@ void MainWindow::on_treeMap_currentItemChanged(QTreeWidgetItem* current, QTreeWi
 
 void MainWindow::on_actionMapCopy_triggered()
 {
-	m_copiedMap = core().project()->projectDir().path() + "/Map%1.lmu";
+	m_copiedMap = core().project()->projectDir().path() + (core().project()->projectType() == FileFinder::ProjectType::EasyRpg ? "/Map%1.emu" : "/Map%1.lmu");
 	m_copiedMap = m_copiedMap.arg(QString::number(ui->treeMap->currentItem()->data(1,Qt::DisplayRole).toInt()),
 								  4, QLatin1Char('0'));
 	ui->actionMapPaste->setEnabled(true);
@@ -1130,10 +1130,14 @@ void MainWindow::on_actionMapNew_triggered()
 	ui->treeMap->currentItem()->setSelected(false);
 	item->setSelected(true);
 	core().project()->saveTreeMap();
-	QString path = core().project()->projectDir().path() + "/Map%1.lmu";
+	QString path = core().project()->projectDir().path() + (core().project()->projectType() == FileFinder::ProjectType::EasyRpg ? "/Map%1.emu" : "/Map%1.lmu");
 	path = path.arg(QString::number(info.ID), 4, QLatin1Char('0'));
 	auto lcf_engine = lcf::GetEngineVersion(core().project()->database());
-	lcf::LMU_Reader::Save(path.toStdString(), *map, lcf_engine, core().project()->encoding().toStdString());
+	if (core().project()->projectType() == FileFinder::ProjectType::EasyRpg) {
+		lcf::LMU_Reader::SaveXml(path.toStdString(), *map, lcf_engine);
+	} else {
+		lcf::LMU_Reader::Save(path.toStdString(), *map, lcf_engine, core().project()->encoding().toStdString());
+	}
 	on_treeMap_itemDoubleClicked(item, 0);
 }
 
@@ -1149,7 +1153,12 @@ void MainWindow::on_actionMapPaste_triggered()
 		return;
 	}
 
-	std::unique_ptr<lcf::rpg::Map> map = lcf::LMU_Reader::Load(m_copiedMap.toStdString(), core().project()->encoding().toStdString());
+	std::unique_ptr<lcf::rpg::Map> map;
+	if (core().project()->projectType() == FileFinder::ProjectType::EasyRpg) {
+		map = lcf::LMU_Reader::LoadXml(m_copiedMap.toStdString());
+	} else {
+		map = lcf::LMU_Reader::Load(m_copiedMap.toStdString(), core().project()->encoding().toStdString());
+	}
 	lcf::rpg::MapInfo info;
 	for (size_t i = 0; i < core().project()->treeMap().maps.size(); i++)
 	{
@@ -1215,10 +1224,14 @@ void MainWindow::on_actionMapPaste_triggered()
 	ui->treeMap->currentItem()->setSelected(false);
 	item->setSelected(true);
 	core().project()->saveTreeMap();
-	QString path = core().project()->projectDir().path() + "/Map%1.lmu";
+	QString path = core().project()->projectDir().path() + (core().project()->projectType() == FileFinder::ProjectType::EasyRpg ? "/Map%1.emu" : "/Map%1.lmu");
 	path = path.arg(QString::number(info.ID), 4, QLatin1Char('0'));
 	auto lcf_engine = lcf::GetEngineVersion(core().project()->database());
-	lcf::LMU_Reader::Save(path.toStdString(), *map, lcf_engine, core().project()->encoding().toStdString());
+	if (core().project()->projectType() == FileFinder::ProjectType::EasyRpg) {
+		lcf::LMU_Reader::SaveXml(path.toStdString(), *map, lcf_engine);
+	} else {
+		lcf::LMU_Reader::Save(path.toStdString(), *map, lcf_engine, core().project()->encoding().toStdString());
+	}
 	on_treeMap_itemDoubleClicked(item, 0);
 }
 
@@ -1242,7 +1255,8 @@ void MainWindow::removeMap(const int id)
 	for (int i = 0; i < m_treeItems[id]->childCount(); i++)
 		removeMap(m_treeItems[id]->child(i)->data(1, Qt::DisplayRole).toInt());
 
-	QString mapPath = core().project()->projectDir().path() + "/Map%1.lmu";
+	QString mapPath = core().project()->projectDir().path() + (core().project()->projectType() == FileFinder::ProjectType::EasyRpg ? "/Map%1.emu" : "/Map%1.lmu");
+
 	mapPath = mapPath.arg(QString::number(id), 4, QLatin1Char('0'));
 
 	if (QFileInfo(mapPath).exists())

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1224,9 +1224,16 @@ void MainWindow::on_actionMapPaste_triggered()
 
 void MainWindow::on_actionMapDelete_triggered()
 {
-	removeMap(ui->treeMap->currentItem()->data(1, Qt::DisplayRole).toInt());
+	int result = QMessageBox::question(this,
+		"Delete map",
+		QString("You are about to delete the selected map and its children.\nThis cannot be undone. Do you want to continue?"),
+		QMessageBox::Yes | QMessageBox::No);
 
-	core().project()->saveTreeMap();
+	if (result == QMessageBox::Yes) {
+		removeMap(ui->treeMap->currentItem()->data(1, Qt::DisplayRole).toInt());
+
+		core().project()->saveTreeMap();
+	}
 }
 
 void MainWindow::removeMap(const int id)
@@ -1235,7 +1242,7 @@ void MainWindow::removeMap(const int id)
 	for (int i = 0; i < m_treeItems[id]->childCount(); i++)
 		removeMap(m_treeItems[id]->child(i)->data(1, Qt::DisplayRole).toInt());
 
-	QString mapPath = core().project()->findFile("Map%1.emu");
+	QString mapPath = core().project()->projectDir().path() + "/Map%1.lmu";
 	mapPath = mapPath.arg(QString::number(id), 4, QLatin1Char('0'));
 
 	if (QFileInfo(mapPath).exists())

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -782,7 +782,7 @@
     <string>New Map</string>
    </property>
    <property name="toolTip">
-    <string>Create a new map and add it as children of the current map.</string>
+    <string>Create a new map and add it as child of the current map.</string>
    </property>
   </action>
   <action name="actionMapCopy">


### PR DESCRIPTION
This PR does the following changes:
- Fix crash on creating new maps
- Fix copying and pasting maps (this one didn't work, there was always an error thrown, see #144)
- Fix deletion of maps (they were removed from the map tree, but not from disk)

Fixes: #144