### PR TITLE
Minor fixes

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -480,7 +480,7 @@ void Core::LoadChipset(int n_chipsetid)
 			 */
 			dest_x = tileSize()/2;
 			if (d+r == 10)
-				blit(r_tileSize*5*2, r_tileSize*7/2);
+				blit(r_tileSize*5/2, r_tileSize*7/2);
 			else if (d)
 			{
 				if (l)

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1036,7 +1036,7 @@ void MainWindow::on_actionMapSave_triggered()
 void MainWindow::on_actionMapRevert_triggered()
 {
 	if (currentScene())
-		currentScene()->Load();
+		currentScene()->Load(true);
 }
 
 

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -122,6 +122,7 @@ MainWindow::MainWindow(QWidget *parent) :
 	dlg_db = nullptr;
 	m_paletteScene = new PaletteScene(ui->graphicsPalette);
 	ui->graphicsPalette->setScene(m_paletteScene);
+	ui->graphicsPalette->verticalScrollBar()->setSliderPosition(1);
 	connect(&core(),
 			SIGNAL(toolChanged()),
 			this,

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -498,11 +498,11 @@ void MainWindow::update_actions()
 	ui->actionDrawRectangle->setEnabled(has_project);
 	ui->actionResourceManager->setEnabled(has_project);
 	ui->actionZoom100->setEnabled(has_project);
-	ui->actionMapRevert->setEnabled(has_project);
+	ui->actionMapRevert->setEnabled(currentScene() && currentScene()->isModified());
 	ui->actionZoomIn->setEnabled(has_project);
 	ui->actionZoomOut->setEnabled(has_project);
 	ui->actionSearch->setEnabled(has_project);
-	ui->actionUndo->setEnabled(has_project);
+	ui->actionUndo->setEnabled(currentScene() && currentScene()->isModified());
 	ui->actionZoom->setEnabled(has_project);
 	ui->actionProjectClose->setEnabled(has_project);
 	ui->actionLayerEvents->setEnabled(has_project);
@@ -512,7 +512,7 @@ void MainWindow::update_actions()
 	ui->actionProjectNew->setEnabled(!has_project);
 	ui->actionProjectOpen->setEnabled(!has_project);
 	ui->actionPlayTest->setEnabled(has_project);
-	ui->actionMapSave->setEnabled(has_project);
+	ui->actionMapSave->setEnabled(currentScene() && currentScene()->isModified());
 	ui->actionScriptEditor->setEnabled(has_project);
 	ui->actionTitleBackgroundToggle->setEnabled(has_project);
 	ui->actionMapNew->setEnabled(has_project);

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -859,7 +859,7 @@ void MainWindow::on_tabMap_tabCloseRequested(int index)
 		int result = QMessageBox::question(this,
 										   "Save map changes",
 										   QString("%1 has unsaved changes.\n"
-										   "Do you want to save them before clossing"
+										   "Do you want to save them before closing"
 										   " it?").arg(getTabScene(index)->mapName()),
 										   QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 		switch (result)
@@ -868,7 +868,6 @@ void MainWindow::on_tabMap_tabCloseRequested(int index)
 			getTabScene(index)->Save();
 			break;
 		case (QMessageBox::No):
-			removeView(getTabScene(index)->id());
 			break;
 		case (QMessageBox::Cancel):
 			return;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -768,14 +768,18 @@ void MainWindow::updateToolActions()
 void MainWindow::on_actionProjectClose_triggered()
 {
 	m_settings.setValue(CURRENT_PROJECT_KEY, QString());
-	ui->treeMap->clear();
-	saveAll();
-	core().project().reset();
+	int result = saveAll();
 
-	while (ui->tabMap->currentIndex() != -1)
-		removeView(currentScene()->id());
-	update_actions();
-	setWindowTitle("EasyRPG Editor");
+	if (result == true) {
+		ui->treeMap->clear();
+		while (ui->tabMap->currentIndex() != -1)
+			removeView(currentScene()->id());
+
+		core().project().reset();
+
+		update_actions();
+		setWindowTitle("EasyRPG Editor");
+	}
 }
 
 void MainWindow::on_actionProjectOpen_triggered()
@@ -1005,7 +1009,7 @@ bool MainWindow::saveAll()
 		int result = QMessageBox::question(this,
 										   "Save map changes",
 										   "Some maps have unsaved changes.\n"
-										   "Do you want to save them before clossing them?",
+										   "Do you want to save them before closing them?",
 										   QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
 		switch (result)
 		{

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -397,7 +397,7 @@
     <string>&amp;Quit</string>
    </property>
    <property name="statusTip">
-    <string>Quit EasyRPG</string>
+    <string>Quit EasyRPG Editor</string>
    </property>
   </action>
   <action name="actionMapSave">
@@ -408,7 +408,7 @@
     <string>Save current Map</string>
    </property>
    <property name="statusTip">
-    <string>Save all changes done in maps</string>
+    <string>Save all changes done in current Map</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
@@ -419,10 +419,10 @@
     <string>&amp;Revert Map</string>
    </property>
    <property name="toolTip">
-    <string>Revert currentl Map</string>
+    <string>Revert current Map</string>
    </property>
    <property name="statusTip">
-    <string>Revert changes on all maps</string>
+    <string>Revert changes on current Map</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+R</string>

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -337,7 +337,7 @@ void MapScene::Save()
 	emit mapSaved();
 }
 
-void MapScene::Load()
+void MapScene::Load(bool revert)
 {
 	// FIXME: Many calls to core()
 	const auto& treeMap = m_project.treeMap();
@@ -355,18 +355,24 @@ void MapScene::Load()
 		core().LoadBackground(m_map->parallax_name.c_str());
 	else
 		core().LoadBackground(QString());
-	QList<QGraphicsItem*> lines;
-	for (int x = 0; x <= m_map->width; x++)
-		lines.append(new QGraphicsLineItem(x*core().tileSize(),
-										   0,
-										   x*core().tileSize(),
-										   m_map->height*core().tileSize()));
-	for (int y = 0; y <= m_map->height; y++)
-		lines.append(new QGraphicsLineItem(0,
-										   y*core().tileSize(),
-										   m_map->width*core().tileSize(),
-										   y*core().tileSize()));
-	m_lines = createItemGroup(lines);
+
+	if (!revert) {
+		QList<QGraphicsItem*> lines;
+		for (int x = 0; x <= m_map->width; x++)
+			lines.append(new QGraphicsLineItem(x*core().tileSize(),
+				0,
+				x*core().tileSize(),
+				m_map->height*core().tileSize()));
+
+		for (int y = 0; y <= m_map->height; y++)
+			lines.append(new QGraphicsLineItem(0,
+				y*core().tileSize(),
+				m_map->width*core().tileSize(),
+				y*core().tileSize()));
+
+		m_lines = createItemGroup(lines);
+	}
+
 	redrawMap();
 	m_undoStack->clear();
 	emit mapReverted();

--- a/src/ui/map/map_scene.h
+++ b/src/ui/map/map_scene.h
@@ -70,7 +70,7 @@ public slots:
 
 	void Save();
 
-	void Load();
+	void Load(bool revert = false);
 
 	void undo();
 

--- a/src/ui/other/open_project_dialog.cpp
+++ b/src/ui/other/open_project_dialog.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<Project> OpenProjectDialog::getProject() {
 
 void OpenProjectDialog::refreshProjectList()
 {
-	ui->tableProjects->clearContents();
+	ui->tableProjects->setRowCount(0);
 
 	prjList = Project::enumerate(m_defaultDir);
 


### PR DESCRIPTION
This PR adds some minor fixes:
- Fix empty rows appearing in the project selection dialog upon changing the "path to games folder" value
- Fix new grid being created on reverting map changes
- Fix crash on closing a tab of a changed map if you reject saving the changes
- Fix crash on closing a project when at least two map tabs are open
- Fix drawing of the lower right corner of D blocks in the editor
- Do not enable map save, revert and undo upon project loading, as these functions are supposed to be enabled only if the map has been changed
- Set the initial scrollbar position of the palette view to the top