### PR TITLE
Fix editor compilation on liblcf 0.7.0

### DIFF
--- a/src/model/project.cpp
+++ b/src/model/project.cpp
@@ -199,10 +199,13 @@ QString Project::detectEncoding() {
 	if (enc.empty()) {
 		std::ifstream i(findFile(RM_DB).toStdString(), std::ios::binary);
 		if (i) {
-			std::string dbenc = lcf::ReaderUtil::DetectEncoding(i);
-			lcf::Encoder encoder(dbenc);
-			if (encoder.IsOk()) {
-				enc = dbenc;
+			auto db = lcf::LDB_Reader::Load(i);
+			if (db) {
+				std::string dbenc = lcf::ReaderUtil::DetectEncoding(*db);
+				lcf::Encoder encoder(dbenc);
+				if (encoder.IsOk()) {
+					enc = dbenc;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Since liblcf 0.7.0 the editor could no longer be compiled. The cause was a method which has been removed from liblcf which is still used in the detectEncoding function of the editor. This PR makes some changes in the detectEncoding function to fix this issue.