### PR TITLE
Enable more event page settings

### DIFF
--- a/src/ui/common/rpg_combobox.h
+++ b/src/ui/common/rpg_combobox.h
@@ -49,9 +49,6 @@ public slots:
 		QObject::connect(diag, SIGNAL(valueSelected(int)), this, SLOT(indexChanged(int)));
 	}
 
-signals:
-	void currentIndexChanged(int);
-
 protected:
 	QComboBox* m_comboBox;
 };
@@ -104,7 +101,6 @@ public:
 
 	void indexChanged(int index) override {
 		m_comboBox->setCurrentIndex(index);
-		emit currentIndexChanged(index);
 	};
 
 private:
@@ -148,8 +144,6 @@ RpgComboBox<LCF>::RpgComboBox(QWidget *parent, QAbstractItemModel *model) :
 		connect(dialog);
 		dialog->exec();
 	});
-
-	QObject::connect(m_comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
 }
 
 using ActorRpgComboBox = RpgComboBox<lcf::rpg::Actor>;

--- a/src/ui/common/rpg_combobox.h
+++ b/src/ui/common/rpg_combobox.h
@@ -49,6 +49,9 @@ public slots:
 		QObject::connect(diag, SIGNAL(valueSelected(int)), this, SLOT(indexChanged(int)));
 	}
 
+signals:
+	void currentIndexChanged(int);
+
 protected:
 	QComboBox* m_comboBox;
 };
@@ -101,6 +104,7 @@ public:
 
 	void indexChanged(int index) override {
 		m_comboBox->setCurrentIndex(index);
+		emit currentIndexChanged(index);
 	};
 
 private:
@@ -144,6 +148,8 @@ RpgComboBox<LCF>::RpgComboBox(QWidget *parent, QAbstractItemModel *model) :
 		connect(dialog);
 		dialog->exec();
 	});
+
+	QObject::connect(m_comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(indexChanged(int)));
 }
 
 using ActorRpgComboBox = RpgComboBox<lcf::rpg::Actor>;

--- a/src/ui/event/event_page_widget.cpp
+++ b/src/ui/event/event_page_widget.cpp
@@ -325,8 +325,7 @@ void EventPageWidget::updateGraphic()
 	}
 	else
 	{
-		// FIXME m_charaItem->setBasePix(ToQString(m_eventPage->character_name));
-		m_charaItem->setIndex(m_eventPage->character_index);
+		m_charaItem->refresh(ToQString(m_eventPage->character_name), m_eventPage->character_index);
 		m_charaItem->setFrame(m_eventPage->character_pattern);
 		m_charaItem->setFacing(m_eventPage->character_direction);
 		m_tileItem->setVisible(false);

--- a/src/ui/event/event_page_widget.cpp
+++ b/src/ui/event/event_page_widget.cpp
@@ -32,6 +32,52 @@ EventPageWidget::EventPageWidget(ProjectData& project, QWidget *parent) :
 {
 	ui->setupUi(this);
 
+	ui->comboVarOperation->addItem("Equal to (==)", lcf::rpg::EventPageCondition::Comparison_equal);
+	ui->comboVarOperation->addItem("Greater or equal to (>=)", lcf::rpg::EventPageCondition::Comparison_greater_equal);
+	ui->comboVarOperation->addItem("Lesser or equal to (<=)", lcf::rpg::EventPageCondition::Comparison_less_equal);
+	ui->comboVarOperation->addItem("Greater than (>)", lcf::rpg::EventPageCondition::Comparison_greater);
+	ui->comboVarOperation->addItem("Lesser than (<)", lcf::rpg::EventPageCondition::Comparison_less);
+	ui->comboVarOperation->addItem("Not equal to (!=)", lcf::rpg::EventPageCondition::Comparison_not_equal);
+	ui->comboVarOperation->setCurrentIndex(1);
+
+	ui->comboMoveType->addItem("Stationary", lcf::rpg::EventPage::MoveType_stationary);
+	ui->comboMoveType->addItem("Random", lcf::rpg::EventPage::MoveType_random);
+	ui->comboMoveType->addItem("Vertical", lcf::rpg::EventPage::MoveType_vertical);
+	ui->comboMoveType->addItem("Horizontal", lcf::rpg::EventPage::MoveType_horizontal);
+	ui->comboMoveType->addItem("Toward Hero", lcf::rpg::EventPage::MoveType_toward);
+	ui->comboMoveType->addItem("Away from Hero", lcf::rpg::EventPage::MoveType_away);
+	ui->comboMoveType->addItem("Custom Pattern", lcf::rpg::EventPage::MoveType_custom);
+
+	for (int i = 1; i <= 8; i++) {
+		ui->comboMoveFrequency->addItem(QString("%1").arg(i), i);
+	}
+	ui->comboMoveFrequency->setCurrentIndex(2);
+
+	ui->comboCondition->addItem("Action Key", lcf::rpg::EventPage::Trigger_action);
+	ui->comboCondition->addItem("Touched by Hero", lcf::rpg::EventPage::Trigger_touched);
+	ui->comboCondition->addItem("Collision with Hero", lcf::rpg::EventPage::Trigger_collision);
+	ui->comboCondition->addItem("AutoStart", lcf::rpg::EventPage::Trigger_auto_start);
+	ui->comboCondition->addItem("Parallel Process", lcf::rpg::EventPage::Trigger_parallel);
+
+	ui->comboLayer->addItem("Below Hero", lcf::rpg::EventPage::Layers_below);
+	ui->comboLayer->addItem("Same as Hero", lcf::rpg::EventPage::Layers_same);
+	ui->comboLayer->addItem("Above Hero", lcf::rpg::EventPage::Layers_above);
+
+	ui->comboAnimationType->addItem("Non-Continuous", lcf::rpg::EventPage::AnimType_non_continuous);
+	ui->comboAnimationType->addItem("Continuous", lcf::rpg::EventPage::AnimType_continuous);
+	ui->comboAnimationType->addItem("Fixed Dir/Non-Continuous", lcf::rpg::EventPage::AnimType_fixed_non_continuous);
+	ui->comboAnimationType->addItem("Fixed Dir/Continuous", lcf::rpg::EventPage::AnimType_fixed_continuous);
+	ui->comboAnimationType->addItem("Fixed Graphic", lcf::rpg::EventPage::AnimType_fixed_graphic);
+	ui->comboAnimationType->addItem("Spin Around", lcf::rpg::EventPage::AnimType_spin);
+
+	ui->comboMoveSpeed->addItem("1: (1/8) Normal", lcf::rpg::EventPage::MoveSpeed_eighth);
+	ui->comboMoveSpeed->addItem("2: (1/4) Normal", lcf::rpg::EventPage::MoveSpeed_quarter);
+	ui->comboMoveSpeed->addItem("3: (1/2) Normal", lcf::rpg::EventPage::MoveSpeed_half);
+	ui->comboMoveSpeed->addItem("4: Normal", lcf::rpg::EventPage::MoveSpeed_normal);
+	ui->comboMoveSpeed->addItem("5: Normal x 2", lcf::rpg::EventPage::MoveSpeed_double);
+	ui->comboMoveSpeed->addItem("6: Normal x 4", lcf::rpg::EventPage::MoveSpeed_fourfold);
+	ui->comboMoveSpeed->setCurrentIndex(2);
+
 	m_charaItem = new CharSetGraphicsItem(project);
 	m_tileItem = new QGraphicsPixmapItem();
 	m_scene = new QGraphicsScene(this);
@@ -54,6 +100,29 @@ EventPageWidget::EventPageWidget(ProjectData& project, QWidget *parent) :
 	ui->comboVariable->makeModel(project);
 	ui->comboItem->makeModel(project);
 	ui->comboHero->makeModel(project);
+
+	LcfWidgetBinding::connect<bool>(this, ui->checkSwitchA);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboSwitchA);
+	LcfWidgetBinding::connect<bool>(this, ui->checkSwitchB);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboSwitchB);
+	LcfWidgetBinding::connect<bool>(this, ui->checkVar);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboVariable);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboVarOperation);
+	LcfWidgetBinding::connect<int32_t>(this, ui->spinVarValue);
+	LcfWidgetBinding::connect<bool>(this, ui->checkItem);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboItem);
+	LcfWidgetBinding::connect<bool>(this, ui->checkHero);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboHero);
+	LcfWidgetBinding::connect<bool>(this, ui->checkTimerA);
+	LcfWidgetBinding::connect<bool>(this, ui->checkTimerB);
+	LcfWidgetBinding::connect<bool>(this, ui->checkTransparent);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboMoveType);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboMoveFrequency);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboCondition);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboLayer);
+	LcfWidgetBinding::connect<bool>(this, ui->checkOverlapForbidden);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboAnimationType);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboMoveSpeed);
 }
 
 EventPageWidget::~EventPageWidget()
@@ -70,136 +139,63 @@ lcf::rpg::EventPage *EventPageWidget::eventPage() const
 void EventPageWidget::setEventPage(lcf::rpg::EventPage *eventPage)
 {
 	m_eventPage = eventPage;
-	ui->checkSwitchA->setChecked(eventPage->condition.flags.switch_a);
-	ui->comboSwitchA->setCurrentIndex(eventPage->condition.switch_a_id-1);
-	ui->checkSwitchB->setChecked(eventPage->condition.flags.switch_b);
-	ui->comboSwitchB->setCurrentIndex(eventPage->condition.switch_b_id-1);
-	ui->checkVar->setChecked(eventPage->condition.flags.variable);
-	ui->comboVariable->setCurrentIndex(eventPage->condition.variable_id-1);
-	ui->comboVarOperation->setCurrentIndex(eventPage->condition.compare_operator);
-	ui->spinVarValue->setValue(eventPage->condition.variable_value);
-	ui->checkItem->setChecked(eventPage->condition.flags.item);
-	ui->comboItem->setCurrentIndex(eventPage->condition.item_id-1);
-	ui->checkHero->setChecked(eventPage->condition.flags.actor);
-	ui->comboHero->setCurrentIndex(eventPage->condition.actor_id-1);
-	ui->checkTimerA->setChecked(eventPage->condition.flags.timer);
+	LcfWidgetBinding::bind(ui->checkSwitchA, eventPage->condition.flags.switch_a);
+	LcfWidgetBinding::bind(ui->comboSwitchA, eventPage->condition.switch_a_id);
+	LcfWidgetBinding::bind(ui->checkSwitchB, eventPage->condition.flags.switch_b);
+	LcfWidgetBinding::bind(ui->comboSwitchB, eventPage->condition.switch_b_id);
+	LcfWidgetBinding::bind(ui->checkVar, eventPage->condition.flags.variable);
+	LcfWidgetBinding::bind(ui->comboVariable, eventPage->condition.variable_id);
+	LcfWidgetBinding::bind(ui->comboVarOperation, eventPage->condition.compare_operator);
+	LcfWidgetBinding::bind(ui->spinVarValue, eventPage->condition.variable_value);
+	LcfWidgetBinding::bind(ui->checkItem, eventPage->condition.flags.item);
+	LcfWidgetBinding::bind(ui->comboItem, eventPage->condition.item_id);
+	LcfWidgetBinding::bind(ui->checkHero, eventPage->condition.flags.actor);
+	LcfWidgetBinding::bind(ui->comboHero, eventPage->condition.actor_id);
+	LcfWidgetBinding::bind(ui->checkTimerA, eventPage->condition.flags.timer);
+	LcfWidgetBinding::bind(ui->checkTimerB, eventPage->condition.flags.timer2);
+	LcfWidgetBinding::bind(ui->checkTransparent, eventPage->translucent);
+	LcfWidgetBinding::bind(ui->comboMoveType, eventPage->move_type);
+	LcfWidgetBinding::bind(ui->comboMoveFrequency, eventPage->move_frequency);
+	LcfWidgetBinding::bind(ui->comboCondition, eventPage->trigger);
+	LcfWidgetBinding::bind(ui->comboLayer, eventPage->layer);
+	LcfWidgetBinding::bind(ui->checkOverlapForbidden, eventPage->overlap_forbidden);
+	LcfWidgetBinding::bind(ui->comboAnimationType, eventPage->animation_type);
+	LcfWidgetBinding::bind(ui->comboMoveSpeed, eventPage->move_speed);
+
 	ui->spinTimerAMin->setValue(eventPage->condition.timer_sec/60);
 	ui->spinTimerASec->setValue(eventPage->condition.timer_sec%60);
-	ui->checkTimerB->setChecked(eventPage->condition.flags.timer2);
 	ui->spinTimerBMin->setValue(eventPage->condition.timer2_sec/60);
 	ui->spinTimerBSec->setValue(eventPage->condition.timer2_sec%60);
-	ui->checkTransparent->setChecked(eventPage->translucent);
-	ui->comboMoveType->setCurrentIndex(eventPage->move_type);
-	ui->comboMoveFrequency->setCurrentIndex(eventPage->move_frequency-1);
-	ui->comboCondition->setCurrentIndex(eventPage->trigger);
-	ui->comboLayer->setCurrentIndex(eventPage->layer);
-	ui->checkOverlapForbidden->setChecked(eventPage->overlap_forbidden);
-	ui->comboAnimationType->setCurrentIndex(eventPage->animation_type);
-	ui->comboMoveSpeed->setCurrentIndex(eventPage->move_speed-1);
+
 	m_effect->setEnabled(m_eventPage->translucent);
 	updateGraphic();
 
 	ui->commands->setData(m_project, eventPage);
+
+	ui->comboSwitchA->setEnabled(ui->checkSwitchA->isChecked());
+	ui->comboSwitchB->setEnabled(ui->checkSwitchB->isChecked());
+	ui->comboVariable->setEnabled(ui->checkVar->isChecked());
+	ui->comboVarOperation->setEnabled(ui->checkVar->isChecked());
+	ui->spinVarValue->setEnabled(ui->checkVar->isChecked());
+	ui->spinTimerAMin->setEnabled(ui->checkTimerA->isChecked());
+	ui->spinTimerASec->setEnabled(ui->checkTimerA->isChecked());
+	ui->spinTimerBMin->setEnabled(ui->checkTimerB->isChecked());
+	ui->spinTimerBSec->setEnabled(ui->checkTimerB->isChecked());
+	ui->comboItem->setEnabled(ui->checkItem->isChecked());
+	ui->comboHero->setEnabled(ui->checkHero->isChecked());
+	ui->label->setEnabled(ui->comboMoveType->currentIndex() != lcf::rpg::EventPage::MoveType_stationary);
+	ui->comboMoveFrequency->setEnabled(ui->comboMoveType->currentIndex() != lcf::rpg::EventPage::MoveType_stationary);
 }
 
 void EventPageWidget::on_comboMoveType_currentIndexChanged(int index)
 {
-	if (!m_eventPage)
-		return;
-	ui->label->setEnabled(index != 0);
-	ui->comboMoveFrequency->setEnabled(index != 0);
-	m_eventPage->move_type = index;
+	ui->label->setEnabled(index != lcf::rpg::EventPage::MoveType_stationary);
+	ui->comboMoveFrequency->setEnabled(index != lcf::rpg::EventPage::MoveType_stationary);
 }
 
-void EventPageWidget::on_checkSwitchA_toggled(bool checked)
+void EventPageWidget::on_checkTransparent_toggled(bool checked)
 {
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.switch_a = checked;
-}
-
-void EventPageWidget::on_comboSwitchA_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.switch_a_id = index+1;
-}
-
-void EventPageWidget::on_checkSwitchB_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.switch_b = checked;
-}
-
-void EventPageWidget::on_comboSwitchB_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.switch_b_id = index+1;
-}
-
-void EventPageWidget::on_checkVar_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.variable = checked;
-}
-
-void EventPageWidget::on_comboVariable_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.variable_id = index+1;
-}
-
-void EventPageWidget::on_checkItem_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.item = checked;
-}
-
-void EventPageWidget::on_comboVarOperation_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.compare_operator = index;
-}
-
-void EventPageWidget::on_spinVarValue_valueChanged(int arg1)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.variable_value = arg1;
-}
-
-void EventPageWidget::on_comboItem_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.item_id = index+1;
-}
-
-void EventPageWidget::on_comboHero_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.actor_id = index+1;
-}
-
-void EventPageWidget::on_checkHero_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.actor = checked;
-}
-
-void EventPageWidget::on_checkTimerA_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.timer = checked;
+	m_effect->setEnabled(checked);
 }
 
 void EventPageWidget::on_spinTimerAMin_valueChanged(int arg1)
@@ -216,13 +212,6 @@ void EventPageWidget::on_spinTimerASec_valueChanged(int arg1)
 	m_eventPage->condition.timer_sec = ui->spinTimerAMin->value()*60 + arg1;
 }
 
-void EventPageWidget::on_checkTimerB_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->condition.flags.timer2 = checked;
-}
-
 void EventPageWidget::on_spinTimerBMin_valueChanged(int arg1)
 {
 	if (!m_eventPage)
@@ -235,56 +224,6 @@ void EventPageWidget::on_spinTimerBSec_valueChanged(int arg1)
 	if (!m_eventPage)
 		return;
 	m_eventPage->condition.timer2_sec = ui->spinTimerBMin->value()*60 + arg1;
-}
-
-void EventPageWidget::on_checkTransparent_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->translucent = checked;
-	m_effect->setEnabled(checked);
-}
-
-void EventPageWidget::on_comboMoveFrequency_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->move_frequency = index+1;
-}
-
-void EventPageWidget::on_comboCondition_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->trigger = index;
-}
-
-void EventPageWidget::on_comboLayer_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->layer = index;
-}
-
-void EventPageWidget::on_checkOverlapForbidden_toggled(bool checked)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->overlap_forbidden = checked;
-}
-
-void EventPageWidget::on_comboAnimationType_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->animation_type = index;
-}
-
-void EventPageWidget::on_comboMoveSpeed_currentIndexChanged(int index)
-{
-	if (!m_eventPage)
-		return;
-	m_eventPage->move_speed = index+1;
 }
 
 void EventPageWidget::on_pushSetSprite_clicked()

--- a/src/ui/event/event_page_widget.cpp
+++ b/src/ui/event/event_page_widget.cpp
@@ -87,12 +87,12 @@ void EventPageWidget::setEventPage(lcf::rpg::EventPage *eventPage)
 	ui->spinTimerBSec->setValue(eventPage->condition.timer2_sec%60);
 	ui->checkTransparent->setChecked(eventPage->translucent);
 	ui->comboMoveType->setCurrentIndex(eventPage->move_type);
-	ui->comboMoveSpeed->setCurrentIndex(eventPage->move_speed-1);
+	ui->comboMoveFrequency->setCurrentIndex(eventPage->move_frequency-1);
 	ui->comboCondition->setCurrentIndex(eventPage->trigger);
 	ui->comboLayer->setCurrentIndex(eventPage->layer);
 	ui->checkOverlapForbidden->setChecked(eventPage->overlap_forbidden);
 	ui->comboAnimationType->setCurrentIndex(eventPage->animation_type);
-	ui->comboMoveFrequency->setCurrentIndex(eventPage->move_frequency-1);
+	ui->comboMoveSpeed->setCurrentIndex(eventPage->move_speed-1);
 	m_effect->setEnabled(m_eventPage->translucent);
 	updateGraphic();
 
@@ -104,7 +104,7 @@ void EventPageWidget::on_comboMoveType_currentIndexChanged(int index)
 	if (!m_eventPage)
 		return;
 	ui->label->setEnabled(index != 0);
-	ui->comboMoveSpeed->setEnabled(index != 0);
+	ui->comboMoveFrequency->setEnabled(index != 0);
 	m_eventPage->move_type = index;
 }
 
@@ -249,11 +249,11 @@ void EventPageWidget::on_checkTransparent_toggled(bool checked)
 	m_effect->setEnabled(checked);
 }
 
-void EventPageWidget::on_comboMoveSpeed_currentIndexChanged(int index)
+void EventPageWidget::on_comboMoveFrequency_currentIndexChanged(int index)
 {
 	if (!m_eventPage)
 		return;
-	m_eventPage->move_speed = index+1;
+	m_eventPage->move_frequency = index+1;
 }
 
 void EventPageWidget::on_comboCondition_currentIndexChanged(int index)
@@ -284,11 +284,11 @@ void EventPageWidget::on_comboAnimationType_currentIndexChanged(int index)
 	m_eventPage->animation_type = index;
 }
 
-void EventPageWidget::on_comboMoveFrequency_currentIndexChanged(int index)
+void EventPageWidget::on_comboMoveSpeed_currentIndexChanged(int index)
 {
 	if (!m_eventPage)
 		return;
-	m_eventPage->move_frequency = index+1;
+	m_eventPage->move_speed = index+1;
 }
 
 void EventPageWidget::on_pushSetSprite_clicked()

--- a/src/ui/event/event_page_widget.cpp
+++ b/src/ui/event/event_page_widget.cpp
@@ -138,6 +138,12 @@ lcf::rpg::EventPage *EventPageWidget::eventPage() const
 
 void EventPageWidget::setEventPage(lcf::rpg::EventPage *eventPage)
 {
+	auto& database = m_project.database();
+	const bool isRPG2k3 = database.system.ldb_id == 2003;
+
+	ui->spinVarValue->setMinimum(isRPG2k3 ? -9999999 : -999999);
+	ui->spinVarValue->setMaximum(isRPG2k3 ? 9999999 : 999999);
+
 	m_eventPage = eventPage;
 	LcfWidgetBinding::bind(ui->checkSwitchA, eventPage->condition.flags.switch_a);
 	LcfWidgetBinding::bind(ui->comboSwitchA, eventPage->condition.switch_a_id);
@@ -175,10 +181,11 @@ void EventPageWidget::setEventPage(lcf::rpg::EventPage *eventPage)
 	ui->comboSwitchA->setEnabled(ui->checkSwitchA->isChecked());
 	ui->comboSwitchB->setEnabled(ui->checkSwitchB->isChecked());
 	ui->comboVariable->setEnabled(ui->checkVar->isChecked());
-	ui->comboVarOperation->setEnabled(ui->checkVar->isChecked());
+	ui->comboVarOperation->setEnabled(isRPG2k3 && ui->checkVar->isChecked());
 	ui->spinVarValue->setEnabled(ui->checkVar->isChecked());
 	ui->spinTimerAMin->setEnabled(ui->checkTimerA->isChecked());
 	ui->spinTimerASec->setEnabled(ui->checkTimerA->isChecked());
+	ui->checkTimerB->setEnabled(isRPG2k3);
 	ui->spinTimerBMin->setEnabled(ui->checkTimerB->isChecked());
 	ui->spinTimerBSec->setEnabled(ui->checkTimerB->isChecked());
 	ui->comboItem->setEnabled(ui->checkItem->isChecked());
@@ -191,6 +198,13 @@ void EventPageWidget::on_comboMoveType_currentIndexChanged(int index)
 {
 	ui->label->setEnabled(index != lcf::rpg::EventPage::MoveType_stationary);
 	ui->comboMoveFrequency->setEnabled(index != lcf::rpg::EventPage::MoveType_stationary);
+}
+
+void EventPageWidget::on_checkVar_toggled(bool checked)
+{
+	auto& database = m_project.database();
+	const bool isRPG2k3 = database.system.ldb_id == 2003;
+	ui->comboVarOperation->setEnabled(isRPG2k3 && checked);
 }
 
 void EventPageWidget::on_checkTransparent_toggled(bool checked)

--- a/src/ui/event/event_page_widget.cpp
+++ b/src/ui/event/event_page_widget.cpp
@@ -71,8 +71,11 @@ void EventPageWidget::setEventPage(lcf::rpg::EventPage *eventPage)
 {
 	m_eventPage = eventPage;
 	ui->checkSwitchA->setChecked(eventPage->condition.flags.switch_a);
+	ui->comboSwitchA->setCurrentIndex(eventPage->condition.switch_a_id-1);
 	ui->checkSwitchB->setChecked(eventPage->condition.flags.switch_b);
+	ui->comboSwitchB->setCurrentIndex(eventPage->condition.switch_b_id-1);
 	ui->checkVar->setChecked(eventPage->condition.flags.variable);
+	ui->comboVariable->setCurrentIndex(eventPage->condition.variable_id-1);
 	ui->comboVarOperation->setCurrentIndex(eventPage->condition.compare_operator);
 	ui->spinVarValue->setValue(eventPage->condition.variable_value);
 	ui->checkItem->setChecked(eventPage->condition.flags.item);
@@ -112,49 +115,42 @@ void EventPageWidget::on_checkSwitchA_toggled(bool checked)
 {
 	if (!m_eventPage)
 		return;
-	if (checked) {
-		//int switchId = m_eventPage->condition.switch_a_id-1;
-		//ui->lineSwitchA->setText(formatSwitchCondition(switchId));
-	}
-	else {
-		//ui->lineSwitchA->setText("");
-	}
 	m_eventPage->condition.flags.switch_a = checked;
+}
+
+void EventPageWidget::on_comboSwitchA_currentIndexChanged(int index)
+{
+	if (!m_eventPage)
+		return;
+	m_eventPage->condition.switch_a_id = index+1;
 }
 
 void EventPageWidget::on_checkSwitchB_toggled(bool checked)
 {
 	if (!m_eventPage)
 		return;
-	if (checked) {
-		//int switchId = m_eventPage->condition.switch_b_id-1;
-		//ui->lineSwitchB->setText(formatSwitchCondition(switchId));
-	}
-	else {
-		//ui->lineSwitchB->setText("");
-	}
 	m_eventPage->condition.flags.switch_b = checked;
+}
+
+void EventPageWidget::on_comboSwitchB_currentIndexChanged(int index)
+{
+	if (!m_eventPage)
+		return;
+	m_eventPage->condition.switch_b_id = index+1;
 }
 
 void EventPageWidget::on_checkVar_toggled(bool checked)
 {
 	if (!m_eventPage)
 		return;
-	/*if (checked) {
-		int varId = m_eventPage->condition.variable_id;
-		if (varId >= 1 && varId <= static_cast<int>(core().project()->database().variables.size())) {
-			ui->lineVar->setText(QString("%1: %2").arg(varId)
-				.arg(ToQString
-					 (core().project()->database().variables[static_cast<size_t>(varId) - 1].name)));
-		}
-		else {
-			ui->lineVar->setText(QString("%1: ???").arg(varId));
-		}
-	}
-	else {
-		ui->lineVar->setText("");
-	}*/
 	m_eventPage->condition.flags.variable = checked;
+}
+
+void EventPageWidget::on_comboVariable_currentIndexChanged(int index)
+{
+	if (!m_eventPage)
+		return;
+	m_eventPage->condition.variable_id = index+1;
 }
 
 void EventPageWidget::on_checkItem_toggled(bool checked)
@@ -196,7 +192,7 @@ void EventPageWidget::on_checkHero_toggled(bool checked)
 {
 	if (!m_eventPage)
 		return;
-	m_eventPage->condition.flags.item = checked;
+	m_eventPage->condition.flags.actor = checked;
 }
 
 void EventPageWidget::on_checkTimerA_toggled(bool checked)

--- a/src/ui/event/event_page_widget.h
+++ b/src/ui/event/event_page_widget.h
@@ -81,7 +81,7 @@ private slots:
 
 	void on_checkTransparent_toggled(bool checked);
 
-	void on_comboMoveSpeed_currentIndexChanged(int index);
+	void on_comboMoveFrequency_currentIndexChanged(int index);
 
 	void on_comboCondition_currentIndexChanged(int index);
 
@@ -91,7 +91,7 @@ private slots:
 
 	void on_comboAnimationType_currentIndexChanged(int index);
 
-	void on_comboMoveFrequency_currentIndexChanged(int index);
+	void on_comboMoveSpeed_currentIndexChanged(int index);
 
 	void on_pushSetSprite_clicked();
 

--- a/src/ui/event/event_page_widget.h
+++ b/src/ui/event/event_page_widget.h
@@ -51,9 +51,15 @@ private slots:
 
 	void on_checkSwitchA_toggled(bool checked);
 
+	void on_comboSwitchA_currentIndexChanged(int index);
+
 	void on_checkSwitchB_toggled(bool checked);
 
+	void on_comboSwitchB_currentIndexChanged(int index);
+
 	void on_checkVar_toggled(bool checked);
+
+	void on_comboVariable_currentIndexChanged(int index);
 
 	void on_checkItem_toggled(bool checked);
 

--- a/src/ui/event/event_page_widget.h
+++ b/src/ui/event/event_page_widget.h
@@ -49,6 +49,8 @@ public:
 private slots:
 	void on_comboMoveType_currentIndexChanged(int index);
 
+	void on_checkVar_toggled(bool checked);
+
 	void on_checkTransparent_toggled(bool checked);
 
 	void on_spinTimerAMin_valueChanged(int arg1);

--- a/src/ui/event/event_page_widget.h
+++ b/src/ui/event/event_page_widget.h
@@ -49,55 +49,15 @@ public:
 private slots:
 	void on_comboMoveType_currentIndexChanged(int index);
 
-	void on_checkSwitchA_toggled(bool checked);
-
-	void on_comboSwitchA_currentIndexChanged(int index);
-
-	void on_checkSwitchB_toggled(bool checked);
-
-	void on_comboSwitchB_currentIndexChanged(int index);
-
-	void on_checkVar_toggled(bool checked);
-
-	void on_comboVariable_currentIndexChanged(int index);
-
-	void on_checkItem_toggled(bool checked);
-
-	void on_comboVarOperation_currentIndexChanged(int index);
-
-	void on_spinVarValue_valueChanged(int arg1);
-
-	void on_comboItem_currentIndexChanged(int index);
-
-	void on_comboHero_currentIndexChanged(int index);
-
-	void on_checkHero_toggled(bool checked);
-
-	void on_checkTimerA_toggled(bool checked);
+	void on_checkTransparent_toggled(bool checked);
 
 	void on_spinTimerAMin_valueChanged(int arg1);
 
 	void on_spinTimerASec_valueChanged(int arg1);
 
-	void on_checkTimerB_toggled(bool checked);
-
 	void on_spinTimerBMin_valueChanged(int arg1);
 
 	void on_spinTimerBSec_valueChanged(int arg1);
-
-	void on_checkTransparent_toggled(bool checked);
-
-	void on_comboMoveFrequency_currentIndexChanged(int index);
-
-	void on_comboCondition_currentIndexChanged(int index);
-
-	void on_comboLayer_currentIndexChanged(int index);
-
-	void on_checkOverlapForbidden_toggled(bool checked);
-
-	void on_comboAnimationType_currentIndexChanged(int index);
-
-	void on_comboMoveSpeed_currentIndexChanged(int index);
 
 	void on_pushSetSprite_clicked();
 

--- a/src/ui/event/event_page_widget.ui
+++ b/src/ui/event/event_page_widget.ui
@@ -122,12 +122,6 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="minimum">
-           <number>-999999</number>
-          </property>
-          <property name="maximum">
-           <number>999999</number>
-          </property>
          </widget>
         </item>
        </layout>
@@ -553,22 +547,6 @@
     <hint type="destinationlabel">
      <x>229</x>
      <y>111</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkVar</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>comboVarOperation</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>43</x>
-     <y>92</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>69</x>
-     <y>114</y>
     </hint>
    </hints>
   </connection>

--- a/src/ui/event/event_page_widget.ui
+++ b/src/ui/event/event_page_widget.ui
@@ -43,6 +43,9 @@
         </item>
         <item row="0" column="1">
          <widget class="SwitchRpgComboBox" name="comboSwitchA">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -53,6 +56,9 @@
         </item>
         <item row="1" column="1">
          <widget class="SwitchRpgComboBox" name="comboSwitchB">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -77,6 +83,9 @@
         </item>
         <item row="2" column="1">
          <widget class="VariableRpgComboBox" name="comboVariable">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -117,7 +126,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Greather than (&gt;)</string>
+            <string>Greater than (&gt;)</string>
            </property>
           </item>
           <item>
@@ -226,7 +235,7 @@
            <bool>false</bool>
           </property>
           <property name="suffix">
-           <string>  seconds or less</string>
+           <string> seconds or less</string>
           </property>
           <property name="maximum">
            <number>59</number>
@@ -729,6 +738,24 @@
  </customwidgets>
  <resources/>
  <connections>
+  <connection>
+   <sender>checkSwitchA</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboSwitchA</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkSwitchB</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboSwitchB</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkVar</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboVariable</receiver>
+   <slot>setEnabled(bool)</slot>
+  </connection>
   <connection>
    <sender>checkVar</sender>
    <signal>toggled(bool)</signal>

--- a/src/ui/event/event_page_widget.ui
+++ b/src/ui/event/event_page_widget.ui
@@ -102,32 +102,32 @@
           </property>
           <item>
            <property name="text">
-            <string>Equal to                     (==)</string>
+            <string>Equal to (==)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Greather or equal to (&gt;=)</string>
+            <string>Greater or equal to (&gt;=)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Lesser or equal to     (&lt;=)</string>
+            <string>Lesser or equal to (&lt;=)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Greather than             (&gt;)</string>
+            <string>Greather than (&gt;)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Lesser than                 (&lt;)</string>
+            <string>Lesser than (&lt;)</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Not equal to              (!=)</string>
+            <string>Not equal to (!=)</string>
            </property>
           </item>
          </widget>
@@ -515,15 +515,58 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Speed</string>
+           <string>Frequency</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="comboMoveSpeed">
+         <widget class="QComboBox" name="comboMoveFrequency">
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="currentIndex">
+           <number>2</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>1</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>2</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>3</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>4</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>5</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>6</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>7</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>8</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>
@@ -561,12 +604,9 @@
       </property>
       <item>
        <widget class="QComboBox" name="comboAnimationType">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <item>
          <property name="text">
-          <string>Non-Continuos</string>
+          <string>Non-Continuous</string>
          </property>
         </item>
         <item>
@@ -602,7 +642,7 @@
    <item row="4" column="1" colspan="2">
     <widget class="QGroupBox" name="groupBox_10">
      <property name="title">
-      <string>Move Frequency</string>
+      <string>Move Speed</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <property name="leftMargin">
@@ -618,7 +658,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboMoveFrequency">
+       <widget class="QComboBox" name="comboMoveSpeed">
         <property name="currentIndex">
          <number>2</number>
         </property>

--- a/src/ui/event/event_page_widget.ui
+++ b/src/ui/event/event_page_widget.ui
@@ -308,14 +308,14 @@
        <widget class="QGraphicsView" name="graphicsSprite">
         <property name="minimumSize">
          <size>
-          <width>50</width>
-          <height>66</height>
+          <width>52</width>
+          <height>68</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>48</width>
-          <height>64</height>
+          <width>52</width>
+          <height>68</height>
          </size>
         </property>
         <property name="verticalScrollBarPolicy">

--- a/src/ui/event/event_page_widget.ui
+++ b/src/ui/event/event_page_widget.ui
@@ -109,36 +109,6 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <item>
-           <property name="text">
-            <string>Equal to (==)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Greater or equal to (&gt;=)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Lesser or equal to (&lt;=)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Greater than (&gt;)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Lesser than (&lt;)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Not equal to (!=)</string>
-           </property>
-          </item>
          </widget>
         </item>
         <item>
@@ -381,33 +351,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboCondition">
-        <item>
-         <property name="text">
-          <string>Action Key</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Touched by Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Collision with Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>AutoStart</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Parallel Process</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="QComboBox" name="comboCondition"/>
       </item>
      </layout>
     </widget>
@@ -431,23 +375,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboLayer">
-        <item>
-         <property name="text">
-          <string>Below Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Same as Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Above Hero</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="QComboBox" name="comboLayer"/>
       </item>
       <item>
        <widget class="QCheckBox" name="checkOverlapForbidden">
@@ -478,43 +406,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboMoveType">
-        <item>
-         <property name="text">
-          <string>Stationary</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Random</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Vertical</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Horizontal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Toward Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Away from Hero</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Custom Pattern</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="QComboBox" name="comboMoveType"/>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_9">
@@ -533,49 +425,6 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
-          <property name="currentIndex">
-           <number>2</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>1</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>3</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>4</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>5</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>6</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>7</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>8</string>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>
@@ -612,38 +461,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboAnimationType">
-        <item>
-         <property name="text">
-          <string>Non-Continuous</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Continuous</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Fixed Dir/Non-Countinuous</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Fixed Dir/Countinuous</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Fixed Graphic</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Spin Around</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="QComboBox" name="comboAnimationType"/>
       </item>
      </layout>
     </widget>
@@ -667,41 +485,7 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QComboBox" name="comboMoveSpeed">
-        <property name="currentIndex">
-         <number>2</number>
-        </property>
-        <item>
-         <property name="text">
-          <string>1: (1/8) Normal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>2: (1/4) Normal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>3: (1/2) Normal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>4: Normal</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>5: Normal x 2</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>6: Normal x 4</string>
-         </property>
-        </item>
-       </widget>
+       <widget class="QComboBox" name="comboMoveSpeed"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
This PR enables the selection of the event conditions Switch A ID, Switch B ID, Variable ID, Item ID and Hero ID. Moreover most of the event movement settings can be changed and the event graphic display supports CharSets now.