### PR TITLE
Implement event page management

### DIFF
--- a/src/ui/event/event_dialog.cpp
+++ b/src/ui/event/event_dialog.cpp
@@ -139,13 +139,7 @@ void EventDialog::setEvent(lcf::rpg::Event& event)
 	r_event = event;
 	ui->lineName->setText(ToQString(m_event.name));
 	this->setWindowTitle(QString("EV: %1").arg(m_event.ID));
-	ui->tabEventPages->clear();
-	for (unsigned int i = 0; i < m_event.pages.size(); i++)
-	{
-		EventPageWidget *tab = new EventPageWidget(m_project, this);
-		tab->setEventPage(&(m_event.pages[i]));
-		ui->tabEventPages->addTab(tab,QString::number(i+1));
-	}
+	refreshEventPageTabs();
 }
 
 void EventDialog::apply()
@@ -165,4 +159,21 @@ void EventDialog::ok()
 		lst_result = QDialogButtonBox::Cancel;
 	else
 		lst_result = QDialogButtonBox::Ok;
+}
+
+void EventDialog::on_pushNewPage_clicked() {
+	int cur_index = ui->tabEventPages->currentIndex();
+	m_event.pages.insert(m_event.pages.begin() + cur_index + 1, lcf::rpg::EventPage());
+	refreshEventPageTabs();
+	ui->tabEventPages->setCurrentIndex(cur_index + 1);
+}
+
+void EventDialog::refreshEventPageTabs() {
+	ui->tabEventPages->clear();
+	for (unsigned int i = 0; i < m_event.pages.size(); i++)
+	{
+		EventPageWidget *tab = new EventPageWidget(m_project, this);
+		tab->setEventPage(&(m_event.pages[i]));
+		ui->tabEventPages->addTab(tab,QString::number(i+1));
+	}
 }

--- a/src/ui/event/event_dialog.cpp
+++ b/src/ui/event/event_dialog.cpp
@@ -168,6 +168,13 @@ void EventDialog::on_pushNewPage_clicked() {
 	ui->tabEventPages->setCurrentIndex(cur_index + 1);
 }
 
+void EventDialog::on_pushDeletePage_clicked() {
+	int cur_index = ui->tabEventPages->currentIndex();
+	m_event.pages.erase(m_event.pages.begin() + cur_index);
+	refreshEventPageTabs();
+	ui->tabEventPages->setCurrentIndex(std::max(0, cur_index - 1));
+}
+
 void EventDialog::refreshEventPageTabs() {
 	ui->tabEventPages->clear();
 	for (unsigned int i = 0; i < m_event.pages.size(); i++)
@@ -176,4 +183,5 @@ void EventDialog::refreshEventPageTabs() {
 		tab->setEventPage(&(m_event.pages[i]));
 		ui->tabEventPages->addTab(tab,QString::number(i+1));
 	}
+	ui->pushDeletePage->setEnabled(m_event.pages.size() >= 2);
 }

--- a/src/ui/event/event_dialog.cpp
+++ b/src/ui/event/event_dialog.cpp
@@ -150,6 +150,7 @@ void EventDialog::setEvent(lcf::rpg::Event& event)
 
 void EventDialog::apply()
 {
+	m_event.name = ToDBString(ui->lineName->text());
 	a_event = m_event;
 	if (equalEvents(a_event, r_event))
 		lst_result = QDialogButtonBox::Cancel;
@@ -159,6 +160,7 @@ void EventDialog::apply()
 
 void EventDialog::ok()
 {
+	m_event.name = ToDBString(ui->lineName->text());
 	if (equalEvents(m_event, r_event))
 		lst_result = QDialogButtonBox::Cancel;
 	else

--- a/src/ui/event/event_dialog.cpp
+++ b/src/ui/event/event_dialog.cpp
@@ -168,6 +168,18 @@ void EventDialog::on_pushNewPage_clicked() {
 	ui->tabEventPages->setCurrentIndex(cur_index + 1);
 }
 
+void EventDialog::on_pushCopyPage_clicked() {
+	event_page_clipboard = m_event.pages[ui->tabEventPages->currentIndex()];
+	ui->pushPastePage->setEnabled(true);
+}
+
+void EventDialog::on_pushPastePage_clicked() {
+	int cur_index = ui->tabEventPages->currentIndex();
+	m_event.pages.insert(m_event.pages.begin() + cur_index + 1, event_page_clipboard);
+	refreshEventPageTabs();
+	ui->tabEventPages->setCurrentIndex(cur_index + 1);
+}
+
 void EventDialog::on_pushDeletePage_clicked() {
 	int cur_index = ui->tabEventPages->currentIndex();
 	m_event.pages.erase(m_event.pages.begin() + cur_index);

--- a/src/ui/event/event_dialog.h
+++ b/src/ui/event/event_dialog.h
@@ -50,6 +50,8 @@ private slots:
 
 	void on_pushNewPage_clicked();
 
+	void on_pushDeletePage_clicked();
+
 private:
 	Ui::EventDialog *ui;
 	lcf::rpg::Event m_event;

--- a/src/ui/event/event_dialog.h
+++ b/src/ui/event/event_dialog.h
@@ -50,6 +50,10 @@ private slots:
 
 	void on_pushNewPage_clicked();
 
+	void on_pushCopyPage_clicked();
+
+	void on_pushPastePage_clicked();
+
 	void on_pushDeletePage_clicked();
 
 private:
@@ -59,6 +63,7 @@ private:
 	lcf::rpg::Event a_event;
 	int lst_result;
 	ProjectData& m_project;
+	lcf::rpg::EventPage event_page_clipboard;
 
 	void refreshEventPageTabs();
 };

--- a/src/ui/event/event_dialog.h
+++ b/src/ui/event/event_dialog.h
@@ -48,6 +48,8 @@ private slots:
 
 	void ok();
 
+	void on_pushNewPage_clicked();
+
 private:
 	Ui::EventDialog *ui;
 	lcf::rpg::Event m_event;
@@ -55,4 +57,6 @@ private:
 	lcf::rpg::Event a_event;
 	int lst_result;
 	ProjectData& m_project;
+
+	void refreshEventPageTabs();
 };


### PR DESCRIPTION
This PR implements new event page creation, copying and pasting event pages and the deletion of event pages. Moreover the name of an event can be changed now.