### PR TITLE
Audio picker: Display the set values next to the sliders

### DIFF
--- a/src/ui/picker/picker_audio_widget.cpp
+++ b/src/ui/picker/picker_audio_widget.cpp
@@ -26,7 +26,7 @@ PickerAudioWidget::PickerAudioWidget(const lcf::rpg::Music& music, QWidget *pare
 	ui(new Ui::PickerAudioWidget) {
 	ui->setupUi(this);
 
-	ui->sliderFadeIn->setValue(music.fadein);
+	ui->sliderFadeIn->setValue(music.fadein / 1000);
 	ui->sliderVolume->setValue(music.volume);
 	ui->sliderTempo->setValue(music.tempo);
 	ui->sliderBalance->setValue(music.balance);
@@ -53,7 +53,7 @@ void PickerAudioWidget::fileChanged(const QString& filename) {
 }
 
 int PickerAudioWidget::fadeInTime() const {
-	return ui->sliderFadeIn->value();
+	return ui->sliderFadeIn->value() * 1000;
 }
 
 int PickerAudioWidget::volume() const {
@@ -66,4 +66,20 @@ int PickerAudioWidget::tempo() const {
 
 int PickerAudioWidget::balance() const {
 	return ui->sliderBalance->value();
+}
+
+void PickerAudioWidget::on_sliderFadeIn_valueChanged(int value) {
+	ui->labelFadeIn->setText(QString("%1s").arg(value));
+}
+
+void PickerAudioWidget::on_sliderVolume_valueChanged(int value) {
+	ui->labelVolume->setText(QString("%1%").arg(value));
+}
+
+void PickerAudioWidget::on_sliderTempo_valueChanged(int value) {
+	ui->labelTempo->setText(QString("%1%").arg(value));
+}
+
+void PickerAudioWidget::on_sliderBalance_valueChanged(int value) {
+	ui->labelBalance->setText(QString("%1:%2").arg(100 - value).arg(value));
 }

--- a/src/ui/picker/picker_audio_widget.h
+++ b/src/ui/picker/picker_audio_widget.h
@@ -55,5 +55,10 @@ private:
 
 	Type m_type;
 	QString m_filename;
-};
 
+private slots:
+	void on_sliderFadeIn_valueChanged(int value);
+	void on_sliderVolume_valueChanged(int value);
+	void on_sliderTempo_valueChanged(int value);
+	void on_sliderBalance_valueChanged(int value);
+};

--- a/src/ui/picker/picker_audio_widget.ui
+++ b/src/ui/picker/picker_audio_widget.ui
@@ -33,6 +33,22 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelFadeIn">
+        <property name="text">
+         <string>0s</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -52,6 +68,22 @@
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelVolume">
+        <property name="text">
+         <string>100%</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -80,6 +112,22 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelTempo">
+        <property name="text">
+         <string>100%</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -92,13 +140,29 @@
       <item row="0" column="0">
        <widget class="RpgSlider" name="sliderBalance">
         <property name="maximum">
-         <number>200</number>
+         <number>100</number>
         </property>
         <property name="value">
-         <number>100</number>
+         <number>50</number>
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelBalance">
+        <property name="text">
+         <string>50:50</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight</set>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR makes the audio picker display the set values next to the sliders.