### PR TITLE
Enable editing of map properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,8 @@ set(EDITOR_SOURCES
 	src/ui/picker/picker_charset_widget.h
 	src/ui/picker/picker_faceset_widget.cpp
 	src/ui/picker/picker_faceset_widget.h
+	src/ui/picker/picker_panorama_widget.cpp
+	src/ui/picker/picker_panorama_widget.h
 	src/ui/picker/picker_dialog.cpp
 	src/ui/picker/picker_dialog.h
 	src/ui/picker/picker_dialog.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,8 @@ set(EDITOR_SOURCES
 	src/ui/picker/picker_audio_widget.cpp
 	src/ui/picker/picker_audio_widget.h
 	src/ui/picker/picker_audio_widget.ui
+	src/ui/picker/picker_backdrop_widget.cpp
+	src/ui/picker/picker_backdrop_widget.h
 	src/ui/picker/picker_child_widget.cpp
 	src/ui/picker/picker_child_widget.h
 	src/ui/picker/picker_charset_widget.cpp

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1057,9 +1057,12 @@ void MainWindow::on_treeMap_currentItemChanged(QTreeWidgetItem* current, QTreeWi
 		ui->actionMapDelete->setEnabled(false);
 		return;
 	}
-	ui->actionMapCopy->setEnabled(current->data(1,Qt::DisplayRole).toInt() != 0);
-	ui->actionMapDelete->setEnabled(current->data(1,Qt::DisplayRole).toInt() != 0);
-	core().project()->treeMap().active_node = current->data(1,Qt::DisplayRole).toInt() != 0;
+	int id = current->data(1, Qt::DisplayRole).toInt();
+	ui->actionMapCopy->setEnabled(id != 0);
+	ui->actionMapDelete->setEnabled(id != 0);
+	if (id != 0) {
+		core().project()->treeMap().active_node = id;
+	}
 }
 
 void MainWindow::on_actionMapCopy_triggered()

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1057,12 +1057,6 @@ void MainWindow::on_treeMap_currentItemChanged(QTreeWidgetItem* current, QTreeWi
 		ui->actionMapDelete->setEnabled(false);
 		return;
 	}
-	int id = current->data(1, Qt::DisplayRole).toInt();
-	ui->actionMapCopy->setEnabled(id != 0);
-	ui->actionMapDelete->setEnabled(id != 0);
-	if (id != 0) {
-		core().project()->treeMap().active_node = id;
-	}
 }
 
 void MainWindow::on_actionMapCopy_triggered()

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -1309,7 +1309,7 @@ void MainWindow::on_actionMapProperties_triggered()
 	if (!currentScene())
 		return;
 
-	currentScene()->editMapProperties();
+	currentScene()->editMapProperties(ui->treeMap->currentItem());
 }
 
 void MainWindow::on_actionSearch_triggered()

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -364,6 +364,8 @@ void MapScene::Save(bool properties_changed)
 			treeMap.maps[i] = n_mapInfo; //Apply info changes
 			break;
 		}
+	// Remember last active map
+	treeMap.active_node = n_mapInfo.ID;
 	// FIXME: ProjectData.Project is Const
 	core().project()->saveTreeMap();
 	QString file = QString("Map%1.emu")

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -249,6 +249,7 @@ void MapScene::editMapProperties()
 		}
 
 		Save(true);
+		redrawPanorama();
 		redrawMap();
 		setScale(m_scale);
 	}
@@ -383,10 +384,8 @@ void MapScene::Load(bool revert)
 	m_map = m_project.project().loadMap(n_mapInfo.ID);
 	m_lower =  m_map->lower_layer;
 	m_upper =  m_map->upper_layer;
-	if(m_map->parallax_flag)
-		core().LoadBackground(m_map->parallax_name.c_str());
-	else
-		core().LoadBackground(QString());
+
+	redrawPanorama();
 
 	if (!revert) {
 		redrawGrid();
@@ -1039,6 +1038,14 @@ int MapScene::getFirstFreeId() {
 	}
 
 	return id;
+}
+
+void MapScene::redrawPanorama() {
+	if (m_map->parallax_flag) {
+		core().LoadBackground(m_map->parallax_name.c_str());
+	} else {
+		core().LoadBackground(QString());
+	}
 }
 
 void MapScene::redrawGrid() {

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -242,48 +242,9 @@ void MapScene::editMapProperties()
 
 	MapPropertiesDialog dlg(m_project, n_mapInfo, *m_map, m_view);
 	if (dlg.exec() == QDialog::Accepted) {
-		// Resize map
 		if (m_map->width != old_width || m_map->height != old_height) {
-			auto old_lower_layer = m_map->lower_layer;
-			auto old_upper_layer = m_map->upper_layer;
-			int old_tile_counter = 0;
-
-			m_map->lower_layer.clear();
-			m_map->upper_layer.clear();
-			for (int y = 0; y < m_map->height; y++) {
-				if (y < old_height) {
-					for (int x = 0; x < m_map->width; x++) {
-						if (x < old_width) {
-							m_map->lower_layer.push_back(old_lower_layer[old_tile_counter]);
-							m_map->upper_layer.push_back(old_upper_layer[old_tile_counter]);
-							old_tile_counter++;
-						} else {
-							m_map->lower_layer.push_back(0);
-							m_map->upper_layer.push_back(10000);
-						}
-					}
-					if (m_map->width < old_width) {
-						old_tile_counter += (old_width - m_map->width);
-					}
-				} else {
-					for (int x = 0; x < m_map->width; x++) {
-						m_map->lower_layer.push_back(0);
-						m_map->upper_layer.push_back(10000);
-					}
-				}
-			}
 			setLayerData(Core::LOWER, m_map->lower_layer);
 			setLayerData(Core::UPPER, m_map->upper_layer);
-
-			// Delete out of bounds events
-			if (m_map->width < old_width || m_map->height < old_height) {
-				std::vector<lcf::rpg::Event>::iterator ev;
-				for (ev = m_map->events.begin(); ev != m_map->events.end(); ++ev) {
-					if (ev->x >= m_map->width || ev->y >= m_map->height) {
-						m_map->events.erase(ev);
-					}
-				}
-			}
 		}
 
 		Save(true);

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -245,6 +245,7 @@ void MapScene::editMapProperties()
 		if (m_map->width != old_width || m_map->height != old_height) {
 			setLayerData(Core::LOWER, m_map->lower_layer);
 			setLayerData(Core::UPPER, m_map->upper_layer);
+			redrawGrid();
 		}
 
 		Save(true);
@@ -388,20 +389,7 @@ void MapScene::Load(bool revert)
 		core().LoadBackground(QString());
 
 	if (!revert) {
-		QList<QGraphicsItem*> lines;
-		for (int x = 0; x <= m_map->width; x++)
-			lines.append(new QGraphicsLineItem(x*core().tileSize(),
-				0,
-				x*core().tileSize(),
-				m_map->height*core().tileSize()));
-
-		for (int y = 0; y <= m_map->height; y++)
-			lines.append(new QGraphicsLineItem(0,
-				y*core().tileSize(),
-				m_map->width*core().tileSize(),
-				y*core().tileSize()));
-
-		m_lines = createItemGroup(lines);
+		redrawGrid();
 	}
 
 	redrawMap();
@@ -1051,4 +1039,32 @@ int MapScene::getFirstFreeId() {
 	}
 
 	return id;
+}
+
+void MapScene::redrawGrid() {
+	if (!grid_lines.empty()) {
+		while (!grid_lines.empty()) {
+			QGraphicsItem* line = grid_lines.takeLast();
+			delete line;
+		}
+		destroyItemGroup(m_lines);
+	}
+
+	for (int x = 0; x <= m_map->width; x++) {
+		grid_lines.append(new QGraphicsLineItem(x*core().tileSize(),
+			0,
+			x*core().tileSize(),
+			m_map->height*core().tileSize()));
+	}
+
+	for (int y = 0; y <= m_map->height; y++) {
+		grid_lines.append(new QGraphicsLineItem(0,
+			y*core().tileSize(),
+			m_map->width*core().tileSize(),
+			y*core().tileSize()));
+	}
+
+	m_lines = createItemGroup(grid_lines);
+
+	m_lines->setVisible(core().layer() == Core::EVENT);
 }

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -235,10 +235,11 @@ QMap<int, lcf::rpg::Event*> *MapScene::mapEvents()
 	return events;
 }
 
-void MapScene::editMapProperties()
+void MapScene::editMapProperties(QTreeWidgetItem *item)
 {
 	int old_width = m_map->width;
 	int old_height = m_map->height;
+	lcf::DBString old_name = n_mapInfo.name;
 
 	MapPropertiesDialog dlg(m_project, n_mapInfo, *m_map, m_view);
 	if (dlg.exec() == QDialog::Accepted) {
@@ -252,6 +253,10 @@ void MapScene::editMapProperties()
 		redrawPanorama();
 		redrawMap();
 		setScale(m_scale);
+
+		if (n_mapInfo.name != old_name) {
+			item->setData(0, Qt::DisplayRole, ToQString(n_mapInfo.name));
+		}
 	}
 }
 

--- a/src/ui/map/map_scene.h
+++ b/src/ui/map/map_scene.h
@@ -121,6 +121,7 @@ private:
 	short bind(int x, int y);
 	lcf::rpg::Event* getEventAt(int x, int y);
 	int getFirstFreeId();
+	void redrawPanorama();
 	void redrawGrid();
 
 

--- a/src/ui/map/map_scene.h
+++ b/src/ui/map/map_scene.h
@@ -68,7 +68,7 @@ public slots:
 
 	void onToolChanged();
 
-	void Save();
+	void Save(bool properties_changed = false);
 
 	void Load(bool revert = false);
 

--- a/src/ui/map/map_scene.h
+++ b/src/ui/map/map_scene.h
@@ -25,6 +25,7 @@
 #include <QMap>
 #include <QMenu>
 #include <QUndoStack>
+#include <QTreeWidgetItem>
 #include <memory>
 #include <lcf/rpg/map.h>
 #include <lcf/rpg/mapinfo.h>
@@ -51,7 +52,7 @@ public:
 	void setLayerData(Core::Layer layer, std::vector<short> data);
 	void setEventData(int id, const lcf::rpg::Event &data);
 	QMap<int, lcf::rpg::Event *> *mapEvents();
-	void editMapProperties();
+	void editMapProperties(QTreeWidgetItem *item);
 
 signals:
 

--- a/src/ui/map/map_scene.h
+++ b/src/ui/map/map_scene.h
@@ -121,6 +121,7 @@ private:
 	short bind(int x, int y);
 	lcf::rpg::Event* getEventAt(int x, int y);
 	int getFirstFreeId();
+	void redrawGrid();
 
 
 	QMenu *m_eventMenu;
@@ -150,5 +151,6 @@ private:
 	ProjectData& m_project;
 	lcf::rpg::Event event_clipboard;
 	bool event_clipboard_set = false;
+	QList<QGraphicsItem*> grid_lines;
 };
 

--- a/src/ui/maptree/map_properties_dialog.cpp
+++ b/src/ui/maptree/map_properties_dialog.cpp
@@ -226,8 +226,32 @@ MapPropertiesDialog::~MapPropertiesDialog()
 }
 
 void MapPropertiesDialog::ok() {
+	m_info.name = ToDBString(ui->lineName->text());
+	m_map.chipset_id = ui->comboTileset->currentIndex() + 1;
 	m_map.width = ui->spinWidth->value();
 	m_map.height = ui->spinHeight->value();
+	m_map.scroll_type = ui->comboWrapping->currentIndex();
+	if (ui->radioTeleportParent->isChecked()) {
+		m_info.teleport = 0;
+	} else if (ui->radioTeleportAllow->isChecked()) {
+		m_info.teleport = 1;
+	} else {
+		m_info.teleport = 2;
+	}
+	if (ui->radioEscapeParent->isChecked()) {
+		m_info.escape = 0;
+	} else if (ui->radioEscapeAllow->isChecked()) {
+		m_info.escape = 1;
+	} else {
+		m_info.escape = 2;
+	}
+	if (ui->radioSaveParent->isChecked()) {
+		m_info.save = 0;
+	} else if (ui->radioSaveAllow->isChecked()) {
+		m_info.save = 1;
+	} else {
+		m_info.save = 2;
+	}
 }
 
 void MapPropertiesDialog::on_groupPanorama_toggled(bool arg1)

--- a/src/ui/maptree/map_properties_dialog.cpp
+++ b/src/ui/maptree/map_properties_dialog.cpp
@@ -24,6 +24,7 @@
 #include "ui/picker/picker_panorama_widget.h"
 #include "ui/picker/picker_dialog.h"
 #include <QMessageBox>
+#include "common/lcf_widget_binding.h"
 
 MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo &info, lcf::rpg::Map &map, QWidget *parent) :
 	QDialog(parent),
@@ -34,7 +35,59 @@ MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo
 {
 	ui->setupUi(this);
 
+	m_info_copy = m_info;
+	m_map_copy = m_map;
+
 	auto& database = project.database();
+
+	for (int i = 0; i < static_cast<int>(database.chipsets.size()); i++) {
+		ui->comboTileset->addItem(ToQString(database.chipsets[static_cast<size_t>(i)].name), i + 1);
+	}
+
+	ui->comboWrapping->addItem("None", lcf::rpg::Map::ScrollType_none);
+	ui->comboWrapping->addItem("Vertical", lcf::rpg::Map::ScrollType_vertical);
+	ui->comboWrapping->addItem("Horizontal", lcf::rpg::Map::ScrollType_horizontal);
+	ui->comboWrapping->addItem("Both", lcf::rpg::Map::ScrollType_both);
+
+	m_buttonGroupBGM = new QButtonGroup(this);
+	m_buttonGroupBGM->addButton(ui->radioBGMparent);
+	m_buttonGroupBGM->setId(ui->radioBGMparent, lcf::rpg::MapInfo::MusicType_parent);
+	m_buttonGroupBGM->addButton(ui->radioBGMevent);
+	m_buttonGroupBGM->setId(ui->radioBGMevent, lcf::rpg::MapInfo::MusicType_event);
+	m_buttonGroupBGM->addButton(ui->radioBGMspecify);
+	m_buttonGroupBGM->setId(ui->radioBGMspecify, lcf::rpg::MapInfo::MusicType_specific);
+
+	m_buttonGroupBackdrop = new QButtonGroup(this);
+	m_buttonGroupBackdrop->addButton(ui->radioBackdropParent);
+	m_buttonGroupBackdrop->setId(ui->radioBackdropParent, lcf::rpg::MapInfo::BGMType_parent);
+	m_buttonGroupBackdrop->addButton(ui->radioBackdropTerrain);
+	m_buttonGroupBackdrop->setId(ui->radioBackdropTerrain, lcf::rpg::MapInfo::BGMType_terrain);
+	m_buttonGroupBackdrop->addButton(ui->radioBackdropSpecify);
+	m_buttonGroupBackdrop->setId(ui->radioBackdropSpecify, lcf::rpg::MapInfo::BGMType_specific);
+
+	m_buttonGroupTeleport = new QButtonGroup(this);
+	m_buttonGroupTeleport->addButton(ui->radioTeleportParent);
+	m_buttonGroupTeleport->setId(ui->radioTeleportParent, lcf::rpg::MapInfo::TriState_parent);
+	m_buttonGroupTeleport->addButton(ui->radioTeleportAllow);
+	m_buttonGroupTeleport->setId(ui->radioTeleportAllow, lcf::rpg::MapInfo::TriState_allow);
+	m_buttonGroupTeleport->addButton(ui->radioTeleportForbid);
+	m_buttonGroupTeleport->setId(ui->radioTeleportForbid, lcf::rpg::MapInfo::TriState_forbid);
+
+	m_buttonGroupEscape = new QButtonGroup(this);
+	m_buttonGroupEscape->addButton(ui->radioEscapeParent);
+	m_buttonGroupEscape->setId(ui->radioEscapeParent, lcf::rpg::MapInfo::TriState_parent);
+	m_buttonGroupEscape->addButton(ui->radioEscapeAllow);
+	m_buttonGroupEscape->setId(ui->radioEscapeAllow, lcf::rpg::MapInfo::TriState_allow);
+	m_buttonGroupEscape->addButton(ui->radioEscapeForbid);
+	m_buttonGroupEscape->setId(ui->radioEscapeForbid, lcf::rpg::MapInfo::TriState_forbid);
+
+	m_buttonGroupSave = new QButtonGroup(this);
+	m_buttonGroupSave->addButton(ui->radioSaveParent);
+	m_buttonGroupSave->setId(ui->radioSaveParent, lcf::rpg::MapInfo::TriState_parent);
+	m_buttonGroupSave->addButton(ui->radioSaveAllow);
+	m_buttonGroupSave->setId(ui->radioSaveAllow, lcf::rpg::MapInfo::TriState_allow);
+	m_buttonGroupSave->addButton(ui->radioSaveForbid);
+	m_buttonGroupSave->setId(ui->radioSaveForbid, lcf::rpg::MapInfo::TriState_forbid);
 
 	for (int terrain = 0; terrain < 162; terrain++)
 		m_generatorLowerLayer.push_back(core().translate(terrain, UP+DOWN+LEFT+RIGHT));
@@ -52,52 +105,21 @@ MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo
 	m_ObstacleBItem = new QGraphicsPixmapItem();
 	m_ObstacleCItem = new QGraphicsPixmapItem();
 
-	ui->lineName->setText(ToQString(info.name));
-	ui->lineBGMname->setText(ToQString(info.music.name));
-	ui->lineBackdropName->setText(ToQString(info.background_name));
-	for (int i = 0; i < static_cast<int>(database.chipsets.size()); i++)
-		ui->comboTileset->addItem(ToQString(database.chipsets[static_cast<size_t>(i)].name), i+1);
-	ui->comboTileset->setCurrentIndex(map.chipset_id-1);
-	ui->comboWrapping->setCurrentIndex(map.scroll_type);
-	ui->spinDungeonRoomHeight->setValue(map.generator_height);
-	ui->spinDungeonRoomWidth->setValue(map.generator_width);
-	ui->spinEncounterRate->setValue(info.encounter_steps);
-	ui->spinHeight->setValue(map.height);
-	ui->spinWidth->setValue(map.width);
-	ui->spinHorizontalScrollSpeed->setValue(map.parallax_sx);
-	ui->spinVerticalScrollSpeed->setValue(map.parallax_sy);
-	ui->checkHorizontalAutoscroll->setChecked(map.parallax_auto_loop_x);
-	ui->checkVerticalAutoscroll->setChecked(map.parallax_auto_loop_y);
-	ui->checkDungeonSurroundWithWalls->setChecked(map.generator_surround);
-	ui->groupHorizontalScroll->setChecked(map.parallax_loop_x);
-	ui->groupVerticalScroll->setChecked(map.parallax_loop_y);
-	ui->groupPanorama->setChecked(map.parallax_flag);
-	ui->groupUseGenerator->setChecked(map.generator_flag);
-	ui->radioBackdropParent->setChecked(info.background_type == 0);
-	ui->radioBackdropTerrain->setChecked(info.background_type == 1);
-	ui->radioBackdropSpecify->setChecked(info.background_type == 2);
-	ui->radioBGMparent->setChecked(info.music_type == 0);
-	ui->radioBGMevent->setChecked(info.music_type == 1);
-	ui->radioBGMspecify->setChecked(info.music_type == 2);
-	ui->radioTeleportParent->setChecked(info.teleport == 0);
-	ui->radioTeleportAllow->setChecked(info.teleport == 1);
-	ui->radioTeleportForbid->setChecked(info.teleport == 2);
-	ui->radioEscapeParent->setChecked(info.escape == 0);
-	ui->radioEscapeAllow->setChecked(info.escape == 1);
-	ui->radioEscapeForbid->setChecked(info.escape == 2);
-	ui->radioSaveParent->setChecked(info.save == 0);
-	ui->radioSaveAllow->setChecked(info.save == 1);
-	ui->radioSaveForbid->setChecked(info.save == 2);
-	ui->radioDungeonSinglePassage->setChecked(map.generator_mode == 0);
-	ui->radioDungeonLinkedRooms->setChecked(map.generator_mode == 1);
-	ui->radioDungeonMaze->setChecked(map.generator_mode == 2);
-	ui->radioDungeonOpenRoom->setChecked(map.generator_mode == 3);
-	ui->radioDungeonPassage1_1->setChecked(map.generator_tiles == 0);
-	ui->radioDungeonPassage2_2->setChecked(map.generator_tiles == 1);
-	for (int i = 0; i < static_cast<int>(info.encounters.size()); i++) {
+	ui->spinDungeonRoomHeight->setValue(m_map_copy.generator_height);
+	ui->spinDungeonRoomWidth->setValue(m_map_copy.generator_width);
+	ui->spinEncounterRate->setValue(m_info_copy.encounter_steps);
+	ui->checkDungeonSurroundWithWalls->setChecked(m_map_copy.generator_surround);
+	ui->groupUseGenerator->setChecked(m_map_copy.generator_flag);
+	ui->radioDungeonSinglePassage->setChecked(m_map_copy.generator_mode == 0);
+	ui->radioDungeonLinkedRooms->setChecked(m_map_copy.generator_mode == 1);
+	ui->radioDungeonMaze->setChecked(m_map_copy.generator_mode == 2);
+	ui->radioDungeonOpenRoom->setChecked(m_map_copy.generator_mode == 3);
+	ui->radioDungeonPassage1_1->setChecked(m_map_copy.generator_tiles == 0);
+	ui->radioDungeonPassage2_2->setChecked(m_map_copy.generator_tiles == 1);
+	for (int i = 0; i < static_cast<int>(m_info_copy.encounters.size()); i++) {
 		QTableWidgetItem *item = new QTableWidgetItem();
-		item->setData(Qt::DisplayRole, ToQString(database.troops[static_cast<size_t>(info.encounters[static_cast<size_t>(i)].troop_id)-1].name));
-		item->setData(Qt::UserRole, info.encounters[static_cast<size_t>(i)].troop_id);
+		item->setData(Qt::DisplayRole, ToQString(database.troops[static_cast<size_t>(m_info_copy.encounters[static_cast<size_t>(i)].troop_id)-1].name));
+		item->setData(Qt::UserRole, m_info_copy.encounters[static_cast<size_t>(i)].troop_id);
 		ui->tableEncounters->insertRow(i);
 		ui->tableEncounters->setItem(i, 0, item);
 	}
@@ -126,83 +148,83 @@ MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo
 	ui->graphicsObstacleC->scene()->addItem(m_ObstacleCItem);
 	ui->graphicsUpperWall->scene()->addItem(m_upperWallItem);
 	QPixmap pix(32, 32);
-	if(map.generator_tile_ids.size()>0)
+	if(m_map_copy.generator_tile_ids.size()>0)
 	{
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[0], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[0], QRect(0,0,32,32));
 	core().endPainting();
 	m_ceilingItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[1], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[1], QRect(0,0,32,32));
 	core().endPainting();
 	m_lowerWallItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[2], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[2], QRect(0,0,32,32));
 	core().endPainting();
 	m_upperWallItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[3], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[3], QRect(0,0,32,32));
 	core().endPainting();
 	m_floorAItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[4], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[4], QRect(0,0,32,32));
 	core().endPainting();
 	m_floorBItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[5], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[5], QRect(0,0,32,32));
 	core().endPainting();
 	m_floorCItem->setPixmap(pix);
 
 	pix = QPixmap(64, 64);
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[6], QRect(0,0,32,32));
-	core().renderTile(map.generator_tile_ids[7], QRect(32,0,32,32));
-	core().renderTile(map.generator_tile_ids[8], QRect(0,32,32,32));
-	core().renderTile(map.generator_tile_ids[9], QRect(32,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[6], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[7], QRect(32,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[8], QRect(0,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[9], QRect(32,32,32,32));
 	core().endPainting();
 	m_ObstacleAItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[10], QRect(0,0,32,32));
-	core().renderTile(map.generator_tile_ids[11], QRect(32,0,32,32));
-	core().renderTile(map.generator_tile_ids[12], QRect(0,32,32,32));
-	core().renderTile(map.generator_tile_ids[13], QRect(32,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[10], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[11], QRect(32,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[12], QRect(0,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[13], QRect(32,32,32,32));
 	core().endPainting();
 	m_ObstacleBItem->setPixmap(pix);
 
 	pix.fill();
 	core().beginPainting(pix);
-	core().renderTile(map.generator_tile_ids[14], QRect(0,0,32,32));
-	core().renderTile(map.generator_tile_ids[15], QRect(32,0,32,32));
-	core().renderTile(map.generator_tile_ids[16], QRect(0,32,32,32));
-	core().renderTile(map.generator_tile_ids[17], QRect(32,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[14], QRect(0,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[15], QRect(32,0,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[16], QRect(0,32,32,32));
+	core().renderTile(m_map_copy.generator_tile_ids[17], QRect(32,32,32,32));
 	core().endPainting();
 	m_ObstacleCItem->setPixmap(pix);
 	}
-	if (map.parallax_flag)
+	if (m_map_copy.parallax_flag)
 	{
-		pix = QPixmap(m_project.project().findFile(PANORAMA, ToQString(map.parallax_name), FileFinder::FileType::Image));
+		pix = QPixmap(m_project.project().findFile(PANORAMA, ToQString(m_map_copy.parallax_name), FileFinder::FileType::Image));
 		if (!pix)
-			pix = QPixmap(core().rtpPath(PANORAMA,ToQString(map.parallax_name)));
+			pix = QPixmap(core().rtpPath(PANORAMA,ToQString(m_map_copy.parallax_name)));
 		m_panoramaItem->setPixmap(pix);
 	}
 
 	//TODO: Show generator tiles.
-	if (info.parent_map == 0)
+	if (m_info_copy.parent_map == 0)
 	{
 		ui->radioBackdropParent->setEnabled(false);
 		ui->radioBGMparent->setEnabled(false);
@@ -211,11 +233,54 @@ MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo
 		ui->radioEscapeParent->setEnabled(false);
 	}
 
-	new_panorama = map.parallax_name;
-	new_music = info.music;
+	new_panorama = m_map_copy.parallax_name;
+	new_music = m_info_copy.music;
 
-	old_width = map.width;
-	old_height = map.height;
+	old_width = m_map_copy.width;
+	old_height = m_map_copy.height;
+
+	ui->lineBGMname->setText(ToQString(m_info_copy.music.name));
+
+	LcfWidgetBinding::connect(this, ui->lineName);
+	LcfWidgetBinding::connect(this, ui->lineBackdropName);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboTileset);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboWrapping);
+	LcfWidgetBinding::connect<int32_t>(this, ui->spinWidth);
+	LcfWidgetBinding::connect<int32_t>(this, ui->spinHeight);
+	LcfWidgetBinding::connect<bool>(this, ui->groupPanorama);
+	LcfWidgetBinding::connect<bool>(this, ui->groupHorizontalScroll);
+	LcfWidgetBinding::connect<bool>(this, ui->groupVerticalScroll);
+	LcfWidgetBinding::connect<bool>(this, ui->checkHorizontalAutoscroll);
+	LcfWidgetBinding::connect<bool>(this, ui->checkVerticalAutoscroll);
+	LcfWidgetBinding::connect<int32_t>(this, ui->spinHorizontalScrollSpeed);
+	LcfWidgetBinding::connect<int32_t>(this, ui->spinVerticalScrollSpeed);
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroupBGM);
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroupBackdrop);
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroupTeleport);
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroupEscape);
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroupSave);
+
+	LcfWidgetBinding::bind(ui->lineName, m_info_copy.name);
+	LcfWidgetBinding::bind(ui->lineBackdropName, m_info_copy.background_name);
+	LcfWidgetBinding::bind(ui->comboTileset, m_map_copy.chipset_id);
+	LcfWidgetBinding::bind(ui->comboWrapping, m_map_copy.scroll_type);
+	LcfWidgetBinding::bind(ui->spinWidth, m_map_copy.width);
+	LcfWidgetBinding::bind(ui->spinHeight, m_map_copy.height);
+	LcfWidgetBinding::bind(ui->groupPanorama, m_map_copy.parallax_flag);
+	LcfWidgetBinding::bind(ui->groupHorizontalScroll, m_map_copy.parallax_loop_x);
+	LcfWidgetBinding::bind(ui->groupVerticalScroll, m_map_copy.parallax_loop_y);
+	LcfWidgetBinding::bind(ui->checkHorizontalAutoscroll, m_map_copy.parallax_auto_loop_x);
+	LcfWidgetBinding::bind(ui->checkVerticalAutoscroll, m_map_copy.parallax_auto_loop_y);
+	LcfWidgetBinding::bind(ui->spinHorizontalScrollSpeed, m_map_copy.parallax_sx);
+	LcfWidgetBinding::bind(ui->spinVerticalScrollSpeed, m_map_copy.parallax_sy);
+	LcfWidgetBinding::bind(m_buttonGroupBGM, m_info_copy.music_type);
+	LcfWidgetBinding::bind(m_buttonGroupBackdrop, m_info_copy.background_type);
+	LcfWidgetBinding::bind(m_buttonGroupTeleport, m_info_copy.teleport);
+	LcfWidgetBinding::bind(m_buttonGroupEscape, m_info_copy.escape);
+	LcfWidgetBinding::bind(m_buttonGroupSave, m_info_copy.save);
+
+	ui->spinHorizontalScrollSpeed->setEnabled(m_map_copy.parallax_auto_loop_x);
+	ui->spinVerticalScrollSpeed->setEnabled(m_map_copy.parallax_auto_loop_y);
 }
 
 MapPropertiesDialog::~MapPropertiesDialog()
@@ -235,8 +300,8 @@ MapPropertiesDialog::~MapPropertiesDialog()
 }
 
 void MapPropertiesDialog::accept() {
-	int width = ui->spinWidth->value();
-	int height = ui->spinHeight->value();
+	int width = m_map_copy.width;
+	int height = m_map_copy.height;
 	if (width < old_width || height < old_height) {
 		int result = QMessageBox::question(this,
 			"Shrink map",
@@ -248,95 +313,49 @@ void MapPropertiesDialog::accept() {
 		}
 	}
 
-	m_info.name = ToDBString(ui->lineName->text());
-	m_map.chipset_id = ui->comboTileset->currentIndex() + 1;
-	m_map.width = width;
-	m_map.height = height;
-	m_map.scroll_type = ui->comboWrapping->currentIndex();
 	if (ui->groupPanorama->isChecked()) {
-		m_map.parallax_flag = true;
-		m_map.parallax_name = new_panorama;
-		m_map.parallax_loop_x = ui->groupHorizontalScroll->isChecked();
-		m_map.parallax_loop_y = ui->groupVerticalScroll->isChecked();
-		m_map.parallax_auto_loop_x = ui->checkHorizontalAutoscroll->isChecked();
-		m_map.parallax_auto_loop_y = ui->checkVerticalAutoscroll->isChecked();
-		m_map.parallax_sx = ui->spinHorizontalScrollSpeed->value();
-		m_map.parallax_sy = ui->spinVerticalScrollSpeed->value();
+		m_map_copy.parallax_name = new_panorama;
 	} else {
-		m_map.parallax_flag = false;
-		m_map.parallax_name = ToDBString("");
-		m_map.parallax_loop_x = false;
-		m_map.parallax_loop_y = false;
-		m_map.parallax_auto_loop_x = false;
-		m_map.parallax_auto_loop_y = false;
-		m_map.parallax_sx = 0;
-		m_map.parallax_sy = 0;
+		m_map_copy.parallax_flag = false;
+		m_map_copy.parallax_name = ToDBString("");
+		m_map_copy.parallax_loop_x = false;
+		m_map_copy.parallax_loop_y = false;
+		m_map_copy.parallax_auto_loop_x = false;
+		m_map_copy.parallax_auto_loop_y = false;
+		m_map_copy.parallax_sx = 0;
+		m_map_copy.parallax_sy = 0;
 	}
-	if (ui->radioBGMparent->isChecked()) {
-		m_info.music_type = 0;
-	} else if (ui->radioBGMevent->isChecked()) {
-		m_info.music_type = 1;
-	} else {
-		m_info.music_type = 2;
-	}
+
 	new_music.name = ui->lineBGMname->text().toStdString();
-	m_info.music = new_music;
-	if (ui->radioBackdropParent->isChecked()) {
-		m_info.background_type = 0;
-	} else if (ui->radioBackdropTerrain->isChecked()) {
-		m_info.background_type = 1;
-	} else {
-		m_info.background_type = 2;
-	}
-	m_info.background_name = ToDBString(ui->lineBackdropName->text());
-	if (ui->radioTeleportParent->isChecked()) {
-		m_info.teleport = 0;
-	} else if (ui->radioTeleportAllow->isChecked()) {
-		m_info.teleport = 1;
-	} else {
-		m_info.teleport = 2;
-	}
-	if (ui->radioEscapeParent->isChecked()) {
-		m_info.escape = 0;
-	} else if (ui->radioEscapeAllow->isChecked()) {
-		m_info.escape = 1;
-	} else {
-		m_info.escape = 2;
-	}
-	if (ui->radioSaveParent->isChecked()) {
-		m_info.save = 0;
-	} else if (ui->radioSaveAllow->isChecked()) {
-		m_info.save = 1;
-	} else {
-		m_info.save = 2;
-	}
-	m_info.encounters.clear();
+	m_info_copy.music = new_music;
+
+	m_info_copy.encounters.clear();
 	for (int i = 0; i < ui->tableEncounters->rowCount(); i++) {
 		QTableWidgetItem *item = ui->tableEncounters->item(i, 0);
 		lcf::rpg::Encounter enc;
 		enc.troop_id = item->data(Qt::UserRole).toInt();
-		m_info.encounters.push_back(enc);
+		m_info_copy.encounters.push_back(enc);
 	}
-	m_info.encounter_steps = ui->spinEncounterRate->value();
+	m_info_copy.encounter_steps = ui->spinEncounterRate->value();
 
 	// Resize map if map bounds have been changed
 	if (width != old_width || height != old_height) {
-		auto old_lower_layer = m_map.lower_layer;
-		auto old_upper_layer = m_map.upper_layer;
+		auto old_lower_layer = m_map_copy.lower_layer;
+		auto old_upper_layer = m_map_copy.upper_layer;
 		int old_tile_counter = 0;
 
-		m_map.lower_layer.clear();
-		m_map.upper_layer.clear();
+		m_map_copy.lower_layer.clear();
+		m_map_copy.upper_layer.clear();
 		for (int y = 0; y < height; y++) {
 			if (y < old_height) {
 				for (int x = 0; x < width; x++) {
 					if (x < old_width) {
-						m_map.lower_layer.push_back(old_lower_layer[old_tile_counter]);
-						m_map.upper_layer.push_back(old_upper_layer[old_tile_counter]);
+						m_map_copy.lower_layer.push_back(old_lower_layer[old_tile_counter]);
+						m_map_copy.upper_layer.push_back(old_upper_layer[old_tile_counter]);
 						old_tile_counter++;
 					} else {
-						m_map.lower_layer.push_back(0);
-						m_map.upper_layer.push_back(10000);
+						m_map_copy.lower_layer.push_back(0);
+						m_map_copy.upper_layer.push_back(10000);
 					}
 				}
 				if (width < old_width) {
@@ -344,24 +363,27 @@ void MapPropertiesDialog::accept() {
 				}
 			} else {
 				for (int x = 0; x < width; x++) {
-					m_map.lower_layer.push_back(0);
-					m_map.upper_layer.push_back(10000);
+					m_map_copy.lower_layer.push_back(0);
+					m_map_copy.upper_layer.push_back(10000);
 				}
 			}
 		}
 
 		// Delete out of bounds events
 		if (width < old_width || height < old_height) {
-			std::vector<lcf::rpg::Event>::iterator ev = m_map.events.begin();
-			while (ev != m_map.events.end()) {
+			std::vector<lcf::rpg::Event>::iterator ev = m_map_copy.events.begin();
+			while (ev != m_map_copy.events.end()) {
 				if (ev->x >= width || ev->y >= height) {
-					ev = m_map.events.erase(ev);
+					ev = m_map_copy.events.erase(ev);
 				} else {
 					++ev;
 				}
 			}
 		}
 	}
+
+	m_info = m_info_copy;
+	m_map = m_map_copy;
 
 	QDialog::accept();
 }

--- a/src/ui/maptree/map_properties_dialog.cpp
+++ b/src/ui/maptree/map_properties_dialog.cpp
@@ -28,7 +28,8 @@ MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo
 	m_project(project)
 {
 	ui->setupUi(this);
-	
+	connect(ui->buttonBox->button(QDialogButtonBox::Ok), SIGNAL(clicked()), this, SLOT(ok()));
+
 	auto& database = project.database();
 
 	for (int terrain = 0; terrain < 162; terrain++)
@@ -222,6 +223,11 @@ MapPropertiesDialog::~MapPropertiesDialog()
 	delete m_ObstacleCItem;
 
 	delete ui;
+}
+
+void MapPropertiesDialog::ok() {
+	m_map.width = ui->spinWidth->value();
+	m_map.height = ui->spinHeight->value();
 }
 
 void MapPropertiesDialog::on_groupPanorama_toggled(bool arg1)

--- a/src/ui/maptree/map_properties_dialog.cpp
+++ b/src/ui/maptree/map_properties_dialog.cpp
@@ -20,6 +20,7 @@
 #include "core.h"
 #include "common/dbstring.h"
 #include "ui/picker/picker_audio_widget.h"
+#include "ui/picker/picker_backdrop_widget.h"
 #include "ui/picker/picker_dialog.h"
 
 MapPropertiesDialog::MapPropertiesDialog(ProjectData& project, lcf::rpg::MapInfo &info, lcf::rpg::Map &map, QWidget *parent) :
@@ -244,6 +245,14 @@ void MapPropertiesDialog::ok() {
 	}
 	new_music.name = ui->lineBGMname->text().toStdString();
 	m_info.music = new_music;
+	if (ui->radioBackdropParent->isChecked()) {
+		m_info.background_type = 0;
+	} else if (ui->radioBackdropTerrain->isChecked()) {
+		m_info.background_type = 1;
+	} else {
+		m_info.background_type = 2;
+	}
+	m_info.background_name = ToDBString(ui->lineBackdropName->text());
 	if (ui->radioTeleportParent->isChecked()) {
 		m_info.teleport = 0;
 	} else if (ui->radioTeleportAllow->isChecked()) {
@@ -346,5 +355,15 @@ void MapPropertiesDialog::on_toolSetBGM_clicked() {
 		new_music.balance = widget->balance();
 	});
 	dialog.setDirectoryAndFile(MUSIC, ui->lineBGMname->text());
+	dialog.exec();
+}
+
+void MapPropertiesDialog::on_toolSetBackdrop_clicked() {
+	auto* widget = new PickerBackdropWidget(this);
+	PickerDialog dialog(m_project, FileFinder::FileType::Image, widget, this);
+	QObject::connect(&dialog, &PickerDialog::fileSelected, [&](const QString& baseName) {
+		ui->lineBackdropName->setText(baseName);
+	});
+	dialog.setDirectoryAndFile(BACKDROP, ui->lineBackdropName->text());
 	dialog.exec();
 }

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -57,6 +57,8 @@ private slots:
 
 	void on_tableEncounters_itemChanged(QTableWidgetItem *item);
 
+	void on_pushSetPanorama_clicked();
+
 	void on_toolSetBGM_clicked();
 
 	void on_toolSetBackdrop_clicked();
@@ -85,6 +87,7 @@ private:
 
 	ProjectData& m_project;
 
+	lcf::DBString new_panorama;
 	lcf::rpg::Music new_music;
 };
 

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -55,7 +55,9 @@ private slots:
 
 	void on_groupObstacleC_toggled(bool arg1);
 
-	void on_tableEncounters_itemChanged(QTableWidgetItem *item);
+	void on_pushAddEncounter_clicked();
+
+	void on_pushRemoveEncounter_clicked();
 
 	void on_pushSetPanorama_clicked();
 

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -59,6 +59,8 @@ private slots:
 
 	void on_toolSetBGM_clicked();
 
+	void on_toolSetBackdrop_clicked();
+
 private:
 	Ui::MapPropertiesDialog *ui;
 

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -39,7 +39,7 @@ public:
 	~MapPropertiesDialog();
 
 private slots:
-	void ok();
+	void accept();
 
 	void on_groupPanorama_toggled(bool arg1);
 
@@ -89,5 +89,8 @@ private:
 
 	lcf::DBString new_panorama;
 	lcf::rpg::Music new_music;
+
+	int old_width;
+	int old_height;
 };
 

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -23,6 +23,7 @@
 #include <lcf/rpg/mapinfo.h>
 #include <lcf/rpg/map.h>
 #include "ui/common/encounter_delegate.h"
+#include <QButtonGroup>
 
 class ProjectData;
 
@@ -83,6 +84,8 @@ private:
 
 	lcf::rpg::MapInfo &m_info;
 	lcf::rpg::Map &m_map;
+	lcf::rpg::MapInfo m_info_copy;
+	lcf::rpg::Map m_map_copy;
 
 	std::vector<short> m_generatorLowerLayer;
 	std::vector<short> m_generatorUpperLayer;
@@ -94,5 +97,11 @@ private:
 
 	int old_width;
 	int old_height;
+
+	QButtonGroup* m_buttonGroupBGM = nullptr;
+	QButtonGroup* m_buttonGroupBackdrop = nullptr;
+	QButtonGroup* m_buttonGroupTeleport = nullptr;
+	QButtonGroup* m_buttonGroupEscape = nullptr;
+	QButtonGroup* m_buttonGroupSave = nullptr;
 };
 

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -39,6 +39,8 @@ public:
 	~MapPropertiesDialog();
 
 private slots:
+	void ok();
+
 	void on_groupPanorama_toggled(bool arg1);
 
 	void on_groupUseGenerator_toggled(bool arg1);

--- a/src/ui/maptree/map_properties_dialog.h
+++ b/src/ui/maptree/map_properties_dialog.h
@@ -57,6 +57,8 @@ private slots:
 
 	void on_tableEncounters_itemChanged(QTableWidgetItem *item);
 
+	void on_toolSetBGM_clicked();
+
 private:
 	Ui::MapPropertiesDialog *ui;
 
@@ -80,5 +82,7 @@ private:
 	std::vector<short> m_generatorUpperLayer;
 
 	ProjectData& m_project;
+
+	lcf::rpg::Music new_music;
 };
 

--- a/src/ui/maptree/map_properties_dialog.ui
+++ b/src/ui/maptree/map_properties_dialog.ui
@@ -166,7 +166,20 @@
           </property>
           <layout class="QGridLayout" name="layoutPanorama">
            <item row="0" column="0" colspan="2">
-            <widget class="QGraphicsView" name="graphicsPanorama"/>
+            <widget class="QGraphicsView" name="graphicsPanorama">
+             <property name="minimumSize">
+              <size>
+               <width>324</width>
+               <height>244</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>324</width>
+               <height>244</height>
+              </size>
+             </property>
+            </widget>
            </item>
            <item row="1" column="0" colspan="2">
             <widget class="QPushButton" name="pushSetPanorama">

--- a/src/ui/maptree/map_properties_dialog.ui
+++ b/src/ui/maptree/map_properties_dialog.ui
@@ -125,37 +125,30 @@
              <attribute name="verticalHeaderDefaultSectionSize">
               <number>21</number>
              </attribute>
-             <row>
-              <property name="text">
-               <string/>
-              </property>
-             </row>
              <column>
               <property name="text">
                <string>Name</string>
               </property>
              </column>
-             <item row="0" column="0">
-              <property name="text">
-               <string>&lt;Add Encounter&gt;</string>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="foreground">
-               <brush brushstyle="NoBrush">
-                <color alpha="255">
-                 <red>85</red>
-                 <green>170</green>
-                 <blue>0</blue>
-                </color>
-               </brush>
-              </property>
-             </item>
             </widget>
+           </item>
+           <item>
+            <layout class="QGridLayout" name="layoutAddRemoveEncounter">
+             <item row="0" column="0">
+              <widget class="QPushButton" name="pushAddEncounter">
+               <property name="text">
+                <string>Add</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QPushButton" name="pushRemoveEncounter">
+               <property name="text">
+                <string>Remove</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
             <layout class="QHBoxLayout" name="layoutEncounterRate">

--- a/src/ui/maptree/map_properties_dialog.ui
+++ b/src/ui/maptree/map_properties_dialog.ui
@@ -79,28 +79,7 @@
           </property>
           <layout class="QVBoxLayout" name="layoutWrapping">
            <item>
-            <widget class="QComboBox" name="comboWrapping">
-             <item>
-              <property name="text">
-               <string>None</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Vertical</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Horizontal</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Both</string>
-              </property>
-             </item>
-            </widget>
+            <widget class="QComboBox" name="comboWrapping"/>
            </item>
           </layout>
          </widget>

--- a/src/ui/maptree/map_properties_dialog.ui
+++ b/src/ui/maptree/map_properties_dialog.ui
@@ -56,10 +56,18 @@
           </property>
           <layout class="QHBoxLayout" name="layoutDimensions">
            <item>
-            <widget class="QSpinBox" name="spinWidth"/>
+            <widget class="QSpinBox" name="spinWidth">
+             <property name="minimum">
+              <number>20</number>
+             </property>
+            </widget>
            </item>
            <item>
-            <widget class="QSpinBox" name="spinHeight"/>
+            <widget class="QSpinBox" name="spinHeight">
+             <property name="minimum">
+              <number>15</number>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/src/ui/picker/picker_backdrop_widget.cpp
+++ b/src/ui/picker/picker_backdrop_widget.cpp
@@ -1,0 +1,29 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picker_backdrop_widget.h"
+#include "ui/viewer/rpg_graphics_view.h"
+#include <QGraphicsScene>
+
+void PickerBackdropWidget::imageChanged(QPixmap image) {
+	if (!m_pixmap) {
+		m_pixmap = new QGraphicsPixmapItem(image);
+	}
+
+	m_pixmap->setPixmap(image);
+	m_view->setItem(m_pixmap);
+}

--- a/src/ui/picker/picker_backdrop_widget.cpp
+++ b/src/ui/picker/picker_backdrop_widget.cpp
@@ -21,6 +21,8 @@
 
 void PickerBackdropWidget::imageChanged(QPixmap image) {
 	if (!m_pixmap) {
+		m_view->setMinimumSize(324, 244);
+		m_view->setMaximumSize(324, 244);
 		m_pixmap = new QGraphicsPixmapItem(image);
 	}
 

--- a/src/ui/picker/picker_backdrop_widget.h
+++ b/src/ui/picker/picker_backdrop_widget.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+#include "picker_child_widget.h"
+
+class QGraphicsScene;
+class QGraphicsPixmapItem;
+
+class PickerBackdropWidget : public PickerChildWidget {
+	Q_OBJECT
+public:
+	PickerBackdropWidget(QWidget* parent = nullptr) : PickerChildWidget(parent) {}
+
+	void imageChanged(QPixmap image) override;
+
+private:
+	QGraphicsPixmapItem* m_pixmap = nullptr;
+};

--- a/src/ui/picker/picker_panorama_widget.cpp
+++ b/src/ui/picker/picker_panorama_widget.cpp
@@ -21,6 +21,8 @@
 
 void PickerPanoramaWidget::imageChanged(QPixmap image) {
 	if (!m_pixmap) {
+		m_view->setMinimumSize(324, 244);
+		m_view->setMaximumSize(324, 244);
 		m_pixmap = new QGraphicsPixmapItem(image);
 	}
 

--- a/src/ui/picker/picker_panorama_widget.cpp
+++ b/src/ui/picker/picker_panorama_widget.cpp
@@ -1,0 +1,29 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picker_panorama_widget.h"
+#include "ui/viewer/rpg_graphics_view.h"
+#include <QGraphicsScene>
+
+void PickerPanoramaWidget::imageChanged(QPixmap image) {
+	if (!m_pixmap) {
+		m_pixmap = new QGraphicsPixmapItem(image);
+	}
+
+	m_pixmap->setPixmap(image);
+	m_view->setItem(m_pixmap);
+}

--- a/src/ui/picker/picker_panorama_widget.h
+++ b/src/ui/picker/picker_panorama_widget.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+#include "picker_child_widget.h"
+
+class QGraphicsScene;
+class QGraphicsPixmapItem;
+
+class PickerPanoramaWidget : public PickerChildWidget {
+	Q_OBJECT
+public:
+	PickerPanoramaWidget(QWidget* parent = nullptr) : PickerChildWidget(parent) {}
+
+	void imageChanged(QPixmap image) override;
+
+private:
+	QGraphicsPixmapItem* m_pixmap = nullptr;
+};


### PR DESCRIPTION
This PR enables editing all map properties except of the random dungeon generator settings. Moreover the RPG_RT.lmt no longer gets overwritten if a map is being opened (fixes #129).