### PR TITLE
Fix map save confirmation cancelling on application quit

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -451,9 +451,10 @@ bool MainWindow::convertXYZtoPNG(QFile &xyz_file, QString out_path)
 
 void MainWindow::on_actionQuit_triggered()
 {
-	saveAll();
-//	  this->on_actionJukebox_triggered(true);
-	qApp->quit();
+	if (saveAll()) {
+		//this->on_actionJukebox_triggered(true);
+		qApp->quit();
+	}
 }
 
 void MainWindow::on_actionPaletteToggle_triggered(bool checked)


### PR DESCRIPTION
If a map has been changed and the quit command has been called, cancelling the map save confirmation dialog quitted the application anyway (same outcome as selecting "No") while working correctly if the dialog was called over the window close command. This PR fixes this.