### PR TITLE
Database: Add editing of all settings from common events

### DIFF
--- a/src/ui/database/common_event_widget.cpp
+++ b/src/ui/database/common_event_widget.cpp
@@ -26,9 +26,14 @@ CommonEventWidget::CommonEventWidget(ProjectData& project, QWidget *parent) :
 {
 	ui->setupUi(this);
 
+	ui->comboTrigger->addItem("Disabled", lcf::rpg::CommonEvent::Trigger_call);
+	ui->comboTrigger->addItem("Foreground", lcf::rpg::CommonEvent::Trigger_automatic);
+	ui->comboTrigger->addItem("Background", lcf::rpg::CommonEvent::Trigger_parallel);
+
 	LcfWidgetBinding::connect(this, ui->lineName);
 	LcfWidgetBinding::connect<int32_t>(this, ui->comboTrigger);
 	LcfWidgetBinding::connect<bool>(this, ui->groupSwitch);
+	LcfWidgetBinding::connect<int32_t>(this, ui->comboSwitch);
 	ui->comboSwitch->makeModel(project);
 }
 
@@ -43,9 +48,18 @@ void CommonEventWidget::setData(lcf::rpg::CommonEvent* common_event) {
 	LcfWidgetBinding::bind(ui->lineName, m_current->name);
 	LcfWidgetBinding::bind(ui->comboTrigger, m_current->trigger);
 	LcfWidgetBinding::bind(ui->groupSwitch, m_current->switch_flag);
-	LcfWidgetBinding::bind(ui->comboSwitch->comboBox(), m_current->switch_id);
+	LcfWidgetBinding::bind(ui->comboSwitch, m_current->switch_id);
 
 	ui->commands->setData(m_project, m_current);
 
 	this->setEnabled(common_event != nullptr);
+	updateComboSwitchEnabled();
+}
+
+void CommonEventWidget::on_comboTrigger_currentIndexChanged(int index) {
+	updateComboSwitchEnabled();
+}
+
+void CommonEventWidget::updateComboSwitchEnabled() {
+	ui->groupSwitch->setEnabled(ui->comboTrigger->currentData().toInt() != lcf::rpg::CommonEvent::Trigger_call);
 }

--- a/src/ui/database/common_event_widget.h
+++ b/src/ui/database/common_event_widget.h
@@ -38,7 +38,12 @@ public:
 
 	void setData(lcf::rpg::CommonEvent* common_event);
 
+private slots:
+	void on_comboTrigger_currentIndexChanged(int index);
+
 private:
+	void updateComboSwitchEnabled();
+
 	Ui::CommonEventWidget *ui;
 	ProjectData& m_project;
 	lcf::rpg::CommonEvent *m_current = nullptr;

--- a/src/ui/database/common_event_widget.ui
+++ b/src/ui/database/common_event_widget.ui
@@ -36,23 +36,7 @@
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QComboBox" name="comboTrigger">
-         <item>
-          <property name="text">
-           <string>Disabled</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Foreground</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Background</string>
-          </property>
-         </item>
-        </widget>
+        <widget class="QComboBox" name="comboTrigger"/>
        </item>
       </layout>
      </item>
@@ -63,6 +47,9 @@
        </property>
        <property name="checkable">
         <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
        </property>
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">


### PR DESCRIPTION
This PR makes all settings from common events editable now except of the event command list. To make the event command list fully editable, #194 is required.