### PR TITLE
Database: Small changes in the actor section

### DIFF
--- a/src/model/actor.cpp
+++ b/src/model/actor.cpp
@@ -30,12 +30,19 @@ lcf::rpg::Actor& ActorModel::data() {
 }
 
 QPixmap ActorModel::preview() {
-	QPixmap faceSet = ImageLoader::Load(m_project.project().findFile("FaceSet", ToQString(m_data.face_name), FileFinder::FileType::Image));
+	QString path = m_project.project().findFile("FaceSet", ToQString(m_data.face_name), FileFinder::FileType::Image);
+	if (!path.isEmpty()) {
+		QPixmap faceSet = ImageLoader::Load(path);
+		int x = (m_data.face_index % 4) * 48;
+		int y = (m_data.face_index / 4) * 48;
 
-	int x = (m_data.face_index % 4) * 48;
-	int y = (m_data.face_index / 4) * 48;
+		return faceSet.copy(x, y, 48, 48);
+	} else {
+		QPixmap faceSet = QPixmap(48, 48);
+		faceSet.fill(QColor(255, 255, 255, 0));
 
-	return faceSet.copy(x, y, 48, 48);
+		return faceSet;
+	}
 }
 
 const lcf::rpg::Actor& ActorModel::data() const {

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -40,6 +40,7 @@ ActorWidget::ActorWidget(ProjectData& project, QWidget *parent) :
 
 	m_current = nullptr;
 
+	ui->spinMinLv->setMaximum(kMaxLevel);
 	ui->spinMaxLv->setMaximum(kMaxLevel);
 
 	ui->graphicsBattleset->setScene(new QGraphicsScene(this));
@@ -172,6 +173,18 @@ void ActorWidget::UpdateModels()
 		ui->listAttributeRanks->addItem(database.attributes[i].name.c_str());
 	for (unsigned int i = 0; i < database.states.size(); i++)
 		ui->listStatusRanks->addItem(database.states[i].name.c_str());
+}
+
+void ActorWidget::on_spinMinLv_valueChanged(int value) {
+	if (ui->spinMaxLv->value() < value) {
+		ui->spinMaxLv->setValue(value);
+	}
+}
+
+void ActorWidget::on_spinMaxLv_valueChanged(int value) {
+	if (ui->spinMinLv->value() > value) {
+		ui->spinMinLv->setValue(value);
+	}
 }
 
 void ActorWidget::on_comboBattleset_currentIndexChanged(int index)

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -353,6 +353,10 @@ void ActorWidget::resizeEvent(QResizeEvent *event)
 }
 
 void ActorWidget::faceSetClicked() {
+	if (!m_current) {
+		return;
+	}
+
 	auto* widget = new PickerFacesetWidget(m_current->face_index, this);
 	PickerDialog dialog(m_project, FileFinder::FileType::Image, widget, this);
 	QObject::connect(&dialog, &PickerDialog::fileSelected, [&](const QString& baseName) {
@@ -365,6 +369,10 @@ void ActorWidget::faceSetClicked() {
 }
 
 void ActorWidget::charSetClicked() {
+	if (!m_current) {
+		return;
+	}
+
 	auto* widget = new PickerCharsetWidget(m_current->character_index, this);
 	PickerDialog dialog(m_project, FileFinder::FileType::Image, widget, this);
 	QObject::connect(&dialog, &PickerDialog::fileSelected, [&](const QString& baseName) {

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -51,38 +51,37 @@ ActorWidget::ActorWidget(ProjectData& project, QWidget *parent) :
 		m_dummyCurve.push_back(0);
 	m_hpItem = new CurveItem(Qt::red, m_dummyCurve);
 	m_hpItem->setMaxValue(kMaxHp);
+	m_hpItem->setMaxLevel(kMaxLevel);
 	m_mpItem = new CurveItem(Qt::magenta, m_dummyCurve);
+	m_mpItem->setMaxLevel(kMaxLevel);
 	m_attItem = new CurveItem(Qt::yellow, m_dummyCurve);
+	m_attItem->setMaxLevel(kMaxLevel);
 	m_defItem = new CurveItem(Qt::green, m_dummyCurve);
+	m_defItem->setMaxLevel(kMaxLevel);
 	m_intItem = new CurveItem(Qt::darkBlue, m_dummyCurve);
+	m_intItem->setMaxLevel(kMaxLevel);
 	m_agyItem = new CurveItem(Qt::blue, m_dummyCurve);
+	m_agyItem->setMaxLevel(kMaxLevel);
 
 	ui->graphicsBattleset->setScene(new QGraphicsScene(this));
 	ui->graphicsBattleset->scene()->addItem(m_battlerItem);
 	ui->graphicsBattleset->scene()->setSceneRect(0,0,48,48);
 
-	ui->graphicsHp->setScene(new QGraphicsScene(this));
-	ui->graphicsHp->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsHp->size()));
+	for (auto& uis : {
+			ui->graphicsHp,
+			ui->graphicsMp,
+			ui->graphicsAtt,
+			ui->graphicsDef,
+			ui->graphicsInt,
+			ui->graphicsAgy }) {
+		uis->setScene(new QGraphicsScene(this));
+		uis->scene()->setSceneRect(QRectF(QPointF(0, 0), QSize(uis->size().width() - 4, uis->size().height() - 4)));
+	}
 	ui->graphicsHp->scene()->addItem(m_hpItem);
-
-	ui->graphicsMp->setScene(new QGraphicsScene(this));
-	ui->graphicsMp->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsMp->size()));
 	ui->graphicsMp->scene()->addItem(m_mpItem);
-
-	ui->graphicsAtt->setScene(new QGraphicsScene(this));
-	ui->graphicsAtt->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsAtt->size()));
 	ui->graphicsAtt->scene()->addItem(m_attItem);
-
-	ui->graphicsDef->setScene(new QGraphicsScene(this));
-	ui->graphicsDef->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsDef->size()));
 	ui->graphicsDef->scene()->addItem(m_defItem);
-
-	ui->graphicsInt->setScene(new QGraphicsScene(this));
-	ui->graphicsInt->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsInt->size()));
 	ui->graphicsInt->scene()->addItem(m_intItem);
-
-	ui->graphicsAgy->setScene(new QGraphicsScene(this));
-	ui->graphicsAgy->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsAgy->size()));
 	ui->graphicsAgy->scene()->addItem(m_agyItem);
 
 	UpdateModels();
@@ -344,12 +343,15 @@ void ActorWidget::on_pushApplyProfession_clicked()
 void ActorWidget::resizeEvent(QResizeEvent *event)
 {
 	Q_UNUSED(event)
-	ui->graphicsHp->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsHp->size()));
-	ui->graphicsMp->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsMp->size()));
-	ui->graphicsAtt->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsAtt->size()));
-	ui->graphicsDef->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsDef->size()));
-	ui->graphicsInt->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsInt->size()));
-	ui->graphicsAgy->scene()->setSceneRect(QRectF(QPointF(0,0),ui->graphicsAgy->size()));
+	for (auto& uis : {
+			ui->graphicsHp,
+			ui->graphicsMp,
+			ui->graphicsAtt,
+			ui->graphicsDef,
+			ui->graphicsInt,
+			ui->graphicsAgy }) {
+		uis->scene()->setSceneRect(QRectF(QPointF(0, 0), QSize(uis->size().width() - 4, uis->size().height() - 4)));
+	}
 }
 
 void ActorWidget::faceSetClicked() {

--- a/src/ui/database/actor_widget.h
+++ b/src/ui/database/actor_widget.h
@@ -47,6 +47,8 @@ public slots:
 	void on_currentActorChanged(lcf::rpg::Actor *actor);
 
 private slots:
+	void on_spinMinLv_valueChanged(int value);
+	void on_spinMaxLv_valueChanged(int value);
 	void on_comboBattleset_currentIndexChanged(int index);
 	void on_pushApplyProfession_clicked();
 

--- a/src/ui/database/actor_widget.ui
+++ b/src/ui/database/actor_widget.ui
@@ -315,7 +315,7 @@
          <string> turns</string>
         </property>
         <property name="prefix">
-         <string>1 of </string>
+         <string>1 in </string>
         </property>
         <property name="minimum">
          <number>1</number>
@@ -425,14 +425,14 @@
        <widget class="FaceSetGraphicsView" name="graphicsFaceset">
         <property name="minimumSize">
          <size>
-          <width>96</width>
-          <height>96</height>
+          <width>100</width>
+          <height>100</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>96</width>
-          <height>96</height>
+          <width>100</width>
+          <height>100</height>
          </size>
         </property>
         <property name="verticalScrollBarPolicy">
@@ -470,14 +470,14 @@
        <widget class="CharSetGraphicsView" name="graphicsCharset">
         <property name="minimumSize">
          <size>
-          <width>48</width>
-          <height>64</height>
+          <width>52</width>
+          <height>68</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>48</width>
-          <height>64</height>
+          <width>52</width>
+          <height>68</height>
          </size>
         </property>
         <property name="verticalScrollBarPolicy">
@@ -516,14 +516,14 @@
        <widget class="QGraphicsView" name="graphicsBattleset">
         <property name="minimumSize">
          <size>
-          <width>48</width>
-          <height>48</height>
+          <width>52</width>
+          <height>52</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>48</width>
-          <height>48</height>
+          <width>52</width>
+          <height>52</height>
          </size>
         </property>
         <property name="verticalScrollBarPolicy">
@@ -940,7 +940,7 @@
    <item row="8" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox_379">
      <property name="title">
-      <string>Custome Properties</string>
+      <string>Custom Properties</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_42">
       <item>

--- a/src/ui/picker/picker_charset_widget.cpp
+++ b/src/ui/picker/picker_charset_widget.cpp
@@ -29,6 +29,8 @@ void PickerCharsetWidget::clicked(const QPointF& pos) {
 
 void PickerCharsetWidget::imageChanged(QPixmap image) {
 	if (!m_pixmap) {
+		m_view->setMinimumSize(196, 132);
+		m_view->setMaximumSize(196, 132);
 		m_view->scale(2.0, 2.0);
 		m_pixmap = new QGraphicsPixmapItem();
 	}

--- a/src/ui/picker/picker_faceset_widget.cpp
+++ b/src/ui/picker/picker_faceset_widget.cpp
@@ -28,6 +28,8 @@ void PickerFacesetWidget::clicked(const QPointF& pos) {
 
 void PickerFacesetWidget::imageChanged(QPixmap image) {
 	if (!m_pixmap) {
+		m_view->setMinimumSize(196, 196);
+		m_view->setMaximumSize(196, 196);
 		m_pixmap = new QGraphicsPixmapItem(image);
 	}
 

--- a/src/ui/viewer/charset_graphics_item.cpp
+++ b/src/ui/viewer/charset_graphics_item.cpp
@@ -23,7 +23,12 @@
 #include <lcf/rpg/actor.h>
 
 CharSetGraphicsItem::CharSetGraphicsItem(ProjectData& project, const QPixmap pix) :
-	QGraphicsItem(), m_project(project), m_image(pix) {}
+	QGraphicsItem(), m_project(project), m_image(pix) {
+	if (pix.isNull()) {
+		m_image = QPixmap(24, 32);
+		m_image.fill(QColor(255, 255, 255, 0));
+	}
+}
 
 void setBasePix(const QString &n_pixName);
 
@@ -68,7 +73,13 @@ void CharSetGraphicsItem::refresh(const lcf::rpg::Actor& actor) {
 void CharSetGraphicsItem::refresh(QString filename, int index) {
 	if (m_filename != filename) {
 		m_filename = filename;
-		m_image = ImageLoader::Load(m_project.project().findFile(CHARSET, filename, FileFinder::FileType::Image));
+		QString path = m_project.project().findFile(CHARSET, filename, FileFinder::FileType::Image);
+		if (!path.isEmpty()) {
+			m_image = ImageLoader::Load(path);
+		} else {
+			m_image = QPixmap(48, 48);
+			m_image.fill(QColor(255, 255, 255, 0));
+		}
 	}
 	setIndex(index);
 	update();

--- a/src/ui/viewer/charset_graphics_item.h
+++ b/src/ui/viewer/charset_graphics_item.h
@@ -41,7 +41,7 @@ public:
 		Frame_right = 2
 	};
 
-	explicit CharSetGraphicsItem(ProjectData& project, const QPixmap pix = QPixmap(24, 32));
+	explicit CharSetGraphicsItem(ProjectData& project, const QPixmap pix = QPixmap());
 
 	QRectF boundingRect() const override;
 	void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*) override;

--- a/src/ui/viewer/faceset_graphics_item.cpp
+++ b/src/ui/viewer/faceset_graphics_item.cpp
@@ -25,6 +25,10 @@
 
 FaceSetGraphicsItem::FaceSetGraphicsItem(ProjectData& project, const QPixmap pix) :
 	QGraphicsItem(), m_project(project), m_image(pix) {
+	if (pix.isNull()) {
+		m_image = QPixmap(48, 48);
+		m_image.fill(QColor(255, 255, 255, 0));
+	}
 }
 
 QRect FaceSetGraphicsItem::faceRect() const {
@@ -51,7 +55,13 @@ void FaceSetGraphicsItem::refresh(const lcf::rpg::Actor& actor) {
 void FaceSetGraphicsItem::refresh(QString filename, int index) {
 	if (m_filename != filename) {
 		m_filename = filename;
-		m_image = ImageLoader::Load(m_project.project().findFile(FACESET, filename, FileFinder::FileType::Image));
+		QString path = m_project.project().findFile(FACESET, filename, FileFinder::FileType::Image);
+		if (!path.isEmpty()) {
+			m_image = ImageLoader::Load(path);
+		} else {
+			m_image = QPixmap(48, 48);
+			m_image.fill(QColor(255, 255, 255, 0));
+		}
 	}
 	setIndex(index);
 	update();

--- a/src/ui/viewer/faceset_graphics_item.h
+++ b/src/ui/viewer/faceset_graphics_item.h
@@ -27,7 +27,7 @@ class ProjectData;
 
 class FaceSetGraphicsItem : public QGraphicsItem {
 public:
-	explicit FaceSetGraphicsItem(ProjectData& m_project, const QPixmap pix = QPixmap(192,192));
+	explicit FaceSetGraphicsItem(ProjectData& m_project, const QPixmap pix = QPixmap());
 
 	QRect faceRect() const;
 	QRectF boundingRect() const override;

--- a/src/ui/viewer/stat_curve_graphics_item.cpp
+++ b/src/ui/viewer/stat_curve_graphics_item.cpp
@@ -24,6 +24,7 @@ CurveItem::CurveItem(QColor color, std::vector<int16_t> &data, QGraphicsItem *pa
 {
 	m_color = color;
 	m_maxValue = 999.0;
+	m_maxLevel = 50.0;
 }
 
 QRectF CurveItem::boundingRect() const
@@ -46,7 +47,7 @@ void CurveItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 	QVector<QPointF> p;
 	p.append(r.bottomLeft());
 	for (size_t i = 0; i < m_data.size(); i++)
-		p.append(QPointF((static_cast<qreal>(i)*r.width())/99.0,
+		p.append(QPointF((static_cast<qreal>(i)*r.width())/(m_maxLevel - 1.0),
 						 r.height()-r.height()*static_cast<qreal>(m_data[i])/m_maxValue));
 	p.append(r.bottomRight());
 
@@ -70,6 +71,16 @@ qreal CurveItem::maxValue() const
 void CurveItem::setMaxValue(const qreal &maxValue)
 {
 	m_maxValue = maxValue;
+}
+
+qreal CurveItem::maxLevel() const
+{
+	return m_maxLevel;
+}
+
+void CurveItem::setMaxLevel(const qreal &maxLevel)
+{
+	m_maxLevel = maxLevel;
 }
 
 

--- a/src/ui/viewer/stat_curve_graphics_item.h
+++ b/src/ui/viewer/stat_curve_graphics_item.h
@@ -35,9 +35,13 @@ public:
 	qreal maxValue() const;
 	void setMaxValue(const qreal &maxValue);
 
+	qreal maxLevel() const;
+	void setMaxLevel(const qreal &maxLevel);
+
 private:
 	std::vector<int16_t> m_data;
 	QColor m_color;
 	qreal m_maxValue;
+	qreal m_maxLevel;
 };
 


### PR DESCRIPTION
This PR does the following changes in the actor section of the database:
- Ensure that the initial level setting is never greater than the maximum level setting
- Set faceset size to 100x100
- Set charset size to 52x68
- Set battleset size to 52x52
- Change critical hit rate text to "1 in x turns"
- Fix typo in "Custom properties"
- Fix crash on trying to select a faceset or charset if no actor is selected
- Fix display of the actor stat curves (lower section was cut off)
- Set faceset picker preview size to 196x196
- Set charset picker preview size to 196x132