### PR TITLE
Event caching rewrite (and general map view fixes)

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -222,6 +222,7 @@ void Core::LoadChipset(int n_chipsetid)
 		 * Get base
 		 */
 		QPixmap p_tile(tileSize(), tileSize());
+		p_tile.fill(QColor(0,0,0,0));
 		QPainter p(&p_tile);
 		if (isABWater (terrain_id))
 			p.drawPixmap(0,0,tileSize(),tileSize(),o_chipset.copy(0, 4*r_tileSize,r_tileSize,r_tileSize));
@@ -302,6 +303,7 @@ void Core::LoadChipset(int n_chipsetid)
 
 	/* Register AnimationTiles */
 	QPixmap a_tile(tileSize(), tileSize());
+	a_tile.fill(QColor(0,0,0,0));
 	QPainter a(&a_tile);
 	a.drawPixmap(0,0,tileSize(),tileSize(),o_chipset.copy(3*r_tileSize,4*r_tileSize,r_tileSize,r_tileSize));
 	for (int i = 0; i < 50; i++) {
@@ -377,6 +379,7 @@ void Core::LoadChipset(int n_chipsetid)
 			 * Get base
 			 */
 			QPixmap p_tile(tileSize(), tileSize());
+			p_tile.fill(QColor(0,0,0,0));
 			QPainter p(&p_tile);
 
 			/*
@@ -569,7 +572,7 @@ void Core::LoadBackground(QString name)
 {
 	if (name.isEmpty()) {
 		m_background = QPixmap(640,480);
-		m_background.fill(Qt::magenta);
+		m_background.fill(Qt::black);
 	} else
 		m_background = ImageLoader::Load(project()->findFile(PANORAMA, name, FileFinder::FileType::Image));
 }
@@ -710,9 +713,16 @@ void Core::renderEvent(const lcf::rpg::Event& event, const QRect &dest_rect)
 	if (event.pages[0].character_name.empty())
 		renderTile(static_cast<short>(event.pages[0].character_index+10000), final_rect);
 	else {
-		if (!m_eventCache.contains(event.ID))
-			return;
-		m_painter.drawPixmap(final_rect, m_eventCache.value(event.ID), QRect(0,6,24,24));
+
+		QString check = ToQString(event.pages[0].character_name);
+		int offset = (event.pages[0].character_pattern * 3 + event.pages[0].character_direction);
+		QString offset_string = QString::number(offset);
+		offset_string = check.leftJustified(2, '0');
+		check.append(offset_string);
+
+		if (!m_eventCache.contains(check))
+			cacheEvent(&event, check);
+		m_painter.drawPixmap(final_rect, m_eventCache.value(check), QRect(0,6,24,24));
 	}
 }
 
@@ -852,6 +862,33 @@ lcf::rpg::Event *Core::currentMapEvent(int eventID)
 	return event;
 }
 
+void Core::cacheEvent(lcf::rpg::Event* ev, QString key) {
+	
+	if (ev->pages.empty())
+		return;
+
+	lcf::rpg::EventPage& evp = ev->pages[0];
+	if (evp.character_name.empty())
+		return;
+
+	QString char_name = ToQString(evp.character_name);
+
+	QPixmap charset(ImageLoader::Load(project()->findFile(CHARSET,char_name, FileFinder::FileType::Image)));
+	if (!charset)
+		charset = ImageLoader::Load(rtpPath(CHARSET,char_name));
+	if (!charset)
+	{
+		qWarning()<<"CharSet"<<char_name<<"not found.";
+		charset = createDummyPixmap(288,256);
+	}
+
+	int char_index = evp.character_index;
+	int src_x = (char_index%4)*72 + evp.character_pattern * 24;
+	int src_y = (char_index/4)*128 + evp.character_direction * 32;
+
+	m_eventCache[key] = charset.copy(src_x, src_y, 24, 32);
+}
+
 void Core::setCurrentMapEvents(QMap<int, lcf::rpg::Event *> *events)
 {
 	m_currentMapEvents = events;
@@ -860,28 +897,14 @@ void Core::setCurrentMapEvents(QMap<int, lcf::rpg::Event *> *events)
 	for (QMap<int, lcf::rpg::Event*>::iterator it = events->begin(); it != events->end(); ++it)
 	{
 		lcf::rpg::Event* ev = it.value();
-		if (ev->pages.empty())
-			continue;
 
-		lcf::rpg::EventPage& evp = ev->pages[0];
-		if (evp.character_name.empty())
-			continue;
+		QString check = ToQString(ev.pages[0].character_name);
+		int offset = (ev.pages[0].character_pattern * 3 + ev.pages[0].character_direction);
+		QString offset_string = QString::number(offset);
+		offset_string = check.leftJustified(2, '0');
+		check.append(offset_string);
 
-		QString char_name = ToQString(evp.character_name);
-
-		QPixmap charset(ImageLoader::Load(project()->findFile(CHARSET,char_name, FileFinder::FileType::Image)));
-		if (!charset)
-			charset = ImageLoader::Load(rtpPath(CHARSET,char_name));
-		if (!charset)
-		{
-			qWarning()<<"CharSet"<<char_name<<"not found.";
-			charset = createDummyPixmap(288,256);
-		}
-
-		int char_index = evp.character_index;
-		int src_x = (char_index%4)*72 + evp.character_pattern * 24;
-		int src_y = (char_index/4)*128 + evp.character_direction * 32;
-		m_eventCache[it.key()] = charset.copy(src_x, src_y, 24, 32);
+		cacheEvent(*ev, check);
 	}
 }
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -568,13 +568,15 @@ void Core::LoadChipset(int n_chipsetid)
 	emit chipsetChanged();
 }
 
-void Core::LoadBackground(QString name)
+void Core::LoadBackground(QString name, float scale)
 {
 	if (name.isEmpty()) {
 		m_background = QPixmap(640,480);
 		m_background.fill(Qt::black);
 	} else
 		m_background = ImageLoader::Load(project()->findFile(PANORAMA, name, FileFinder::FileType::Image));
+		int height = m_background.height();
+		m_background = m_background.scaledToHeight(int(height * scale));
 }
 
 int Core::tileSize()
@@ -690,15 +692,11 @@ const std::shared_ptr<Project>& Core::project() const {
 void Core::beginPainting(QPixmap &dest)
 {
 	m_painter.begin(&dest);
-	if (m_painter.isActive())
-		m_painter.setBackground(QBrush(m_background));
 	m_painter.setPen(Qt::yellow);
 }
 
 void Core::renderTile(const short &tile_id, const QRect &dest_rect)
 {
-	if (tile_id < 10000)
-		m_painter.fillRect(dest_rect, QBrush(m_background));
 	m_painter.drawPixmap(dest_rect, m_tileCache[tile_id]);
 }
 
@@ -717,6 +715,7 @@ void Core::renderEvent(const lcf::rpg::Event& event, const QRect &dest_rect)
 		QString check = ToQString(event.pages[0].character_name);
 		int offset = (event.pages[0].character_index * 32 + event.pages[0].character_direction * 4 + event.pages[0].character_pattern);
 		QString offset_string = QString::number(offset);
+		offset_string = offset_string.leftJustified(3, QLatin1Char('0'));
 		check.append(offset_string);
 
 		if (!m_eventCache.contains(check))

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -715,9 +715,8 @@ void Core::renderEvent(const lcf::rpg::Event& event, const QRect &dest_rect)
 	else {
 
 		QString check = ToQString(event.pages[0].character_name);
-		int offset = (event.pages[0].character_pattern * 3 + event.pages[0].character_direction);
+		int offset = (event.pages[0].character_index * 32 + event.pages[0].character_direction * 4 + event.pages[0].character_pattern);
 		QString offset_string = QString::number(offset);
-		offset_string = check.leftJustified(2, '0');
 		check.append(offset_string);
 
 		if (!m_eventCache.contains(check))
@@ -867,7 +866,7 @@ void Core::cacheEvent(const lcf::rpg::Event* ev, QString key) {
 	if (ev->pages.empty())
 		return;
 
-	lcf::rpg::EventPage& evp = ev->pages[0];
+	const lcf::rpg::EventPage& evp = ev->pages[0];
 	if (evp.character_name.empty())
 		return;
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -717,6 +717,7 @@ void Core::renderEvent(const lcf::rpg::Event& event, const QRect &dest_rect)
 		QString check = ToQString(event.pages[0].character_name);
 		int offset = (event.pages[0].character_index * 32 + event.pages[0].character_direction * 4 + event.pages[0].character_pattern);
 		QString offset_string = QString::number(offset);
+		offset_string = offset_string.leftJustified(3, QLatin1Char('0'));
 		check.append(offset_string);
 
 		if (!m_eventCache.contains(check))

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -862,7 +862,7 @@ lcf::rpg::Event *Core::currentMapEvent(int eventID)
 	return event;
 }
 
-void Core::cacheEvent(lcf::rpg::Event* ev, QString key) {
+void Core::cacheEvent(const lcf::rpg::Event* ev, QString key) {
 	
 	if (ev->pages.empty())
 		return;
@@ -892,20 +892,6 @@ void Core::cacheEvent(lcf::rpg::Event* ev, QString key) {
 void Core::setCurrentMapEvents(QMap<int, lcf::rpg::Event *> *events)
 {
 	m_currentMapEvents = events;
-
-	m_eventCache.clear();
-	for (QMap<int, lcf::rpg::Event*>::iterator it = events->begin(); it != events->end(); ++it)
-	{
-		lcf::rpg::Event* ev = it.value();
-
-		QString check = ToQString(ev.pages[0].character_name);
-		int offset = (ev.pages[0].character_pattern * 3 + ev.pages[0].character_direction);
-		QString offset_string = QString::number(offset);
-		offset_string = check.leftJustified(2, '0');
-		check.append(offset_string);
-
-		cacheEvent(*ev, check);
-	}
 }
 
 QPixmap Core::createDummyPixmap(int width, int height)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -568,15 +568,13 @@ void Core::LoadChipset(int n_chipsetid)
 	emit chipsetChanged();
 }
 
-void Core::LoadBackground(QString name, float scale)
+void Core::LoadBackground(QString name)
 {
 	if (name.isEmpty()) {
 		m_background = QPixmap(640,480);
 		m_background.fill(Qt::black);
 	} else
 		m_background = ImageLoader::Load(project()->findFile(PANORAMA, name, FileFinder::FileType::Image));
-		int height = m_background.height();
-		m_background = m_background.scaledToHeight(int(height * scale));
 }
 
 int Core::tileSize()
@@ -692,11 +690,15 @@ const std::shared_ptr<Project>& Core::project() const {
 void Core::beginPainting(QPixmap &dest)
 {
 	m_painter.begin(&dest);
+	if (m_painter.isActive())
+		m_painter.setBackground(QBrush(m_background));
 	m_painter.setPen(Qt::yellow);
 }
 
 void Core::renderTile(const short &tile_id, const QRect &dest_rect)
 {
+	if (tile_id < 10000)
+		m_painter.fillRect(dest_rect, QBrush(m_background));
 	m_painter.drawPixmap(dest_rect, m_tileCache[tile_id]);
 }
 
@@ -715,7 +717,6 @@ void Core::renderEvent(const lcf::rpg::Event& event, const QRect &dest_rect)
 		QString check = ToQString(event.pages[0].character_name);
 		int offset = (event.pages[0].character_index * 32 + event.pages[0].character_direction * 4 + event.pages[0].character_pattern);
 		QString offset_string = QString::number(offset);
-		offset_string = offset_string.leftJustified(3, QLatin1Char('0'));
 		check.append(offset_string);
 
 		if (!m_eventCache.contains(check))

--- a/src/core.h
+++ b/src/core.h
@@ -60,7 +60,7 @@ public:
 	static Core* getCore();
 
 	void LoadChipset(int n_chipsetid);
-	void LoadBackground(QString name);
+	void LoadBackground(QString name, float scale);
 
 	int tileSize();
 	void setTileSize(int tileSize);

--- a/src/core.h
+++ b/src/core.h
@@ -109,7 +109,7 @@ public:
 
 	lcf::rpg::Event *currentMapEvent(int eventID);
 	void setCurrentMapEvents(QMap<int, lcf::rpg::Event *> *events);
-	void cacheEvent(lcf::rpg::Event* ev, QString key);
+	void cacheEvent(const lcf::rpg::Event* ev, QString key);
 
 	void runGame();
 	void runGameHere(int map_id, int x, int y);

--- a/src/core.h
+++ b/src/core.h
@@ -60,7 +60,7 @@ public:
 	static Core* getCore();
 
 	void LoadChipset(int n_chipsetid);
-	void LoadBackground(QString name, float scale);
+	void LoadBackground(QString name);
 
 	int tileSize();
 	void setTileSize(int tileSize);

--- a/src/core.h
+++ b/src/core.h
@@ -109,6 +109,7 @@ public:
 
 	lcf::rpg::Event *currentMapEvent(int eventID);
 	void setCurrentMapEvents(QMap<int, lcf::rpg::Event *> *events);
+	void cacheEvent(lcf::rpg::Event* ev, QString key);
 
 	void runGame();
 	void runGameHere(int map_id, int x, int y);
@@ -136,7 +137,7 @@ private:
 	Tool m_tool;
 	QPixmap m_background;
 	QMap<int, QPixmap> m_tileCache;
-	QMap<int, QPixmap> m_eventCache;
+	QMap<QString, QPixmap> m_eventCache;
 	QMap<int, short> m_dictionary;
 	QMap<int, lcf::rpg::Map> m_maps;
 	QMap<int, QWidget*> m_mapTabs;

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -1049,9 +1049,9 @@ int MapScene::getFirstFreeId() {
 
 void MapScene::redrawPanorama() {
 	if (m_map->parallax_flag) {
-		core().LoadBackground(m_map->parallax_name.c_str());
+		core().LoadBackground(m_map->parallax_name.c_str(), m_scale);
 	} else {
-		core().LoadBackground(QString());
+		core().LoadBackground(QString(), m_scale);
 	}
 }
 

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -165,6 +165,8 @@ void MapScene::Init()
 	m_view->verticalScrollBar()->setValue(n_mapInfo.scrollbar_y *static_cast<int>(m_scale));
 	m_view->horizontalScrollBar()->setValue(n_mapInfo.scrollbar_x * static_cast<int>(m_scale));
 	m_init = true;
+	core().setCurrentMapEvents(mapEvents());
+	redrawPanorama();
 	redrawMap();
 }
 
@@ -214,7 +216,6 @@ void MapScene::setEventData(int id, const lcf::rpg::Event &data)
 		if (m_map->events[i].ID == id) {
 			if (m_map->events[i] == data) {
 				m_map->events.erase(m_map->events.begin() + i);
-				redrawMap();
 				return;
 			} else {
 				m_map->events[i] = data;
@@ -265,7 +266,6 @@ void MapScene::redrawMap()
 	if (!m_init)
 		return;
 	core().LoadChipset(m_map->chipset_id);
-	core().setCurrentMapEvents(mapEvents());
 	s_tileSize = core().tileSize() * static_cast<double>(m_scale);
 	redrawLayer(Core::LOWER);
 	redrawLayer(Core::UPPER);

--- a/src/ui/map/map_scene.cpp
+++ b/src/ui/map/map_scene.cpp
@@ -1049,9 +1049,9 @@ int MapScene::getFirstFreeId() {
 
 void MapScene::redrawPanorama() {
 	if (m_map->parallax_flag) {
-		core().LoadBackground(m_map->parallax_name.c_str(), m_scale);
+		core().LoadBackground(m_map->parallax_name.c_str());
 	} else {
-		core().LoadBackground(QString(), m_scale);
+		core().LoadBackground(QString());
 	}
 }
 


### PR DESCRIPTION
This PR rewrites the event cache to update dynamically when drawing events and store graphics by a combination of the charset name and the offset instead of per event ID. This greatly speeds up map loading times and fixes the immense lag present when scrolling.

This PR also sets the default panorama colour from magenta to black, to match in-engine behaviour, and fixes issues with autotile rendering caused by not pre-filling the pixmaps.