### PR TITLE
Add AttributePage, RadioButton, ComboBox

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+  Add: [-W3]
+  Remove: [-fsanitize*, -mno-direct-extern-access]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(EDITOR_SOURCES
 
 set(EDITOR_QML_UI
 	src/ui/common/CheckBox.qml
+	src/ui/common/ComboBox.qml
 	src/ui/common/RadioButton.qml
 	src/ui/common/SpinBox.qml
 	src/ui/common/TextField.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,14 +324,16 @@ set(EDITOR_SOURCES
 
 set(EDITOR_QML_UI
 	src/ui/common/CheckBox.qml
+	src/ui/common/RadioButton.qml
 	src/ui/common/SpinBox.qml
 	src/ui/common/TextField.qml
 	src/ui/MainWindow.qml
-	src/ui/database/DatabaseWindow.qml
 	src/ui/database/ActorPage.qml
+	src/ui/database/AttributePage.qml
 	src/ui/database/DatabaseEntryListPage.qml
 	src/ui/database/DatabaseEntryPage.qml
 	src/ui/database/DatabasePage.qml
+	src/ui/database/DatabaseWindow.qml
 	src/ui/database/ItemPage.qml
 	src/ui/database/SkillPage.qml
 	src/ui/database/VocabularyPage.qml

--- a/src/common/lcf_widget_binding.h
+++ b/src/common/lcf_widget_binding.h
@@ -79,7 +79,7 @@ namespace LcfWidgetBinding {
 			data.obj() = static_cast<T>(checkBox->isChecked());
 		};
 
-		QWidget::connect(checkBox, &QCheckBox::stateChanged, parent, callback);
+		QWidget::connect(checkBox, &QCheckBox::checkStateChanged, parent, callback);
 	}
 
 	template<typename T>

--- a/src/common/sortfilter_proxy_models.cpp
+++ b/src/common/sortfilter_proxy_models.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "sortfilter_proxy_models.h"
+#include "json_list_view.h"
 
 SortFilterProxyModelIdFilter::SortFilterProxyModelIdFilter(const std::vector<int>& indices) :
 		QSortFilterProxyModel() {
@@ -25,7 +26,7 @@ SortFilterProxyModelIdFilter::SortFilterProxyModelIdFilter(const std::vector<int
 
 bool SortFilterProxyModelIdFilter::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const {
 	QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-	int val = sourceModel()->data(index, Qt::UserRole).toInt();
+	int val = sourceModel()->data(index, JsonListView::IdRole).toInt();
 
 	return std::binary_search(this->indices.begin(), this->indices.end(), val);
 }

--- a/src/common/sortfilter_proxy_models.cpp
+++ b/src/common/sortfilter_proxy_models.cpp
@@ -18,8 +18,8 @@
 #include "sortfilter_proxy_models.h"
 #include "json_list_view.h"
 
-SortFilterProxyModelIdFilter::SortFilterProxyModelIdFilter(const std::vector<int>& indices) :
-		QSortFilterProxyModel() {
+SortFilterProxyModelIdFilter::SortFilterProxyModelIdFilter(const std::vector<int>& indices, QObject* parent) :
+		QSortFilterProxyModel(parent) {
 	this->indices = indices;
 	std::sort(this->indices.begin(), this->indices.end());
 }

--- a/src/common/sortfilter_proxy_models.h
+++ b/src/common/sortfilter_proxy_models.h
@@ -28,8 +28,10 @@
  * Filters by a list of Lcf IDs
  */
 class SortFilterProxyModelIdFilter : public QSortFilterProxyModel {
+	Q_OBJECT
+
 public:
-	SortFilterProxyModelIdFilter(const std::vector<int>& indices);
+	SortFilterProxyModelIdFilter(const std::vector<int>& indices, QObject* parent);
 	bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
 
 private:

--- a/src/model/actor.cpp
+++ b/src/model/actor.cpp
@@ -70,7 +70,7 @@ bool ActorModel::IsItemUsable(const lcf::rpg::Item& item) const {
 	return (*query_set)[query_idx];
 }
 
-QAbstractItemModel* ActorModel::CreateEquipmentFilter(lcf::rpg::Item::Type type) {
+QAbstractItemModel* ActorModel::CreateEquipmentFilter(lcf::rpg::Item::Type type, QObject* parent) {
 	std::vector<int> indices = {0}; // Include (None)
 
 	for (const auto& item : m_project->database().items) {
@@ -81,5 +81,11 @@ QAbstractItemModel* ActorModel::CreateEquipmentFilter(lcf::rpg::Item::Type type)
 		indices.push_back(item.ID);
 	}
 
-	return new SortFilterProxyModelIdFilter(indices);
+	auto filter = new SortFilterProxyModelIdFilter(indices, parent);
+
+	if (!parent) {
+        QQmlEngine::setObjectOwnership(filter, QQmlEngine::JavaScriptOwnership);
+    }
+
+	return filter;
 }

--- a/src/model/actor.cpp
+++ b/src/model/actor.cpp
@@ -17,24 +17,25 @@
 
 #include "actor.h"
 #include <lcf/rpg/item.h>
+#include "common/image_loader.h"
 #include "ui/database/actor_widget.h"
 #include "common/dbstring.h"
 #include "common/sortfilter_proxy_models.h"
 
 ActorModel::ActorModel(ProjectData& project, lcf::rpg::Actor& data) :
-	RpgBase(project), m_data(data) {
+	RpgBase(project), m_data(&data) {
 }
 
 lcf::rpg::Actor& ActorModel::data() {
-	return m_data;
+	return *m_data;
 }
 
 QPixmap ActorModel::preview() {
-	QString path = m_project.project().findFile("FaceSet", ToQString(m_data.face_name), FileFinder::FileType::Image);
+	QString path = m_project->project().findFile("FaceSet", ToQString(m_data->face_name), FileFinder::FileType::Image);
 	if (!path.isEmpty()) {
 		QPixmap faceSet = ImageLoader::Load(path);
-		int x = (m_data.face_index % 4) * 48;
-		int y = (m_data.face_index / 4) * 48;
+		int x = (m_data->face_index % 4) * 48;
+		int y = (m_data->face_index / 4) * 48;
 
 		return faceSet.copy(x, y, 48, 48);
 	} else {
@@ -46,11 +47,11 @@ QPixmap ActorModel::preview() {
 }
 
 const lcf::rpg::Actor& ActorModel::data() const {
-        return m_data;
+	return *m_data;
 }
 
 bool ActorModel::IsItemUsable(const lcf::rpg::Item& item) const {
-	int query_idx = m_data.ID - 1;
+	int query_idx = m_data->ID - 1;
 	auto* query_set = &item.actor_set;
 	/*TODO if (Player::IsRPG2k3() && Data::system.equipment_setting == lcf::rpg::System::EquipmentSetting_class) {
 		auto* cls = GetClass();
@@ -69,10 +70,10 @@ bool ActorModel::IsItemUsable(const lcf::rpg::Item& item) const {
 	return (*query_set)[query_idx];
 }
 
-QSortFilterProxyModel* ActorModel::CreateEquipmentFilter(lcf::rpg::Item::Type type) {
-	std::vector<int> indices;
+QAbstractItemModel* ActorModel::CreateEquipmentFilter(lcf::rpg::Item::Type type) {
+	std::vector<int> indices = {0}; // Include (None)
 
-	for (const auto& item : m_project.database().items) {
+	for (const auto& item : m_project->database().items) {
 		if (item.type != type || !IsItemUsable(item)) {
 			continue;
 		}

--- a/src/model/actor.h
+++ b/src/model/actor.h
@@ -20,17 +20,20 @@
 #include <QGraphicsItem>
 #include <lcf/rpg/database.h>
 #include <lcf/rpg/actor.h>
-#include "project.h"
 #include "rpg_base.h"
 
-class QSortFilterProxyModel;
+class QAbstractItemModel;
+class ProjectData;
 
 /**
  * A thin wrapper around lcf::rpg::Actor
  */
 class ActorModel : public RpgBase
 {
+	Q_GADGET
+
 public:
+	ActorModel() = default;
 	ActorModel(ProjectData& project, lcf::rpg::Actor& data);
 
 	bool IsItemUsable(const lcf::rpg::Item& item) const;
@@ -41,7 +44,7 @@ public:
 	 * @param type Equipment type
 	 * @return QSortFilterProxyModel
 	 */
-	QSortFilterProxyModel* CreateEquipmentFilter(lcf::rpg::Item::Type type);
+	Q_INVOKABLE QAbstractItemModel* CreateEquipmentFilter(lcf::rpg::Item::Type type);
 
 	lcf::rpg::Actor& data();
 
@@ -54,6 +57,6 @@ public:
 	QPixmap preview() override;
 
 private:
-	lcf::rpg::Actor& m_data;
+	lcf::rpg::Actor* m_data = nullptr;
 };
 

--- a/src/model/actor.h
+++ b/src/model/actor.h
@@ -44,7 +44,7 @@ public:
 	 * @param type Equipment type
 	 * @return QSortFilterProxyModel
 	 */
-	Q_INVOKABLE QAbstractItemModel* CreateEquipmentFilter(lcf::rpg::Item::Type type);
+	Q_INVOKABLE QAbstractItemModel* CreateEquipmentFilter(lcf::rpg::Item::Type type, QObject* parent = nullptr);
 
 	lcf::rpg::Actor& data();
 

--- a/src/model/enemy.cpp
+++ b/src/model/enemy.cpp
@@ -16,6 +16,10 @@
  */
 
 #include "enemy.h"
+#include "common/filefinder.h"
+#include "common/image_loader.h"
+#include "model/project.h"
+#include "model/project_data.h"
 #include "ui/database/enemy_widget.h"
 #include "common/dbstring.h"
 
@@ -29,7 +33,7 @@ lcf::rpg::Enemy& EnemyModel::data() {
 }
 
 QPixmap EnemyModel::preview() {
-	QPixmap monster = ImageLoader::Load(m_project.project().findFile("Monster", ToQString(data().battler_name), FileFinder::FileType::Image));
+	QPixmap monster = ImageLoader::Load(m_project->project().findFile("Monster", ToQString(data().battler_name), FileFinder::FileType::Image));
 	if (!monster) {
 		return QPixmap(48, 48);
 	}

--- a/src/model/project.cpp
+++ b/src/model/project.cpp
@@ -69,11 +69,11 @@ std::shared_ptr<Project> Project::load(const QDir& dir) {
 
 	if (!cfg.isNull()) {
 		lcf::INIReader ini(cfg.toStdString());
-		auto title = ini.GetString("RPG_RT", GAMETITLE, tr("Untitled").toStdString());
+		std::string title = std::string(ini.GetString("RPG_RT", GAMETITLE, tr("Untitled").toStdString()));
 
 		if (project_type == FileFinder::ProjectType::Legacy) {
 			// Check for game encoding
-			auto enc = ini.GetString("EasyRPG", "Encoding", "");
+			std::string enc = std::string(ini.GetString("EasyRPG", "Encoding", ""));
 			if (enc.empty()) {
 				// Only use the title for encoding detection
 				// This is called for all games in the "Open Project" list

--- a/src/model/rpg_base.cpp
+++ b/src/model/rpg_base.cpp
@@ -18,6 +18,6 @@
 
 #include "rpg_base.h"
 
-RpgBase::RpgBase(ProjectData &project) : m_project(project) {
+RpgBase::RpgBase(ProjectData &project) : m_project(&project) {
 
 }

--- a/src/model/rpg_base.h
+++ b/src/model/rpg_base.h
@@ -19,12 +19,14 @@
 
 #include <QPixmap>
 #include <QMessageBox>
-#include "common/image_loader.h"
-#include "project.h"
-#include "core.h"
+
+class ProjectData;
 
 class RpgBase {
+	Q_GADGET
+
 public:
+	RpgBase() = default;
 	explicit RpgBase(ProjectData& project);
 
 	virtual QPixmap preview() {
@@ -32,9 +34,9 @@ public:
 	}
 
 	ProjectData& project() const {
-		return m_project;
+		return *m_project;
 	}
 
 protected:
-	ProjectData& m_project;
+	ProjectData* m_project = nullptr;
 };

--- a/src/qmlbinding/json.h
+++ b/src/qmlbinding/json.h
@@ -29,6 +29,7 @@
 class Json : public QObject {
 	Q_OBJECT
 	QML_ELEMENT
+	QML_UNCREATABLE("Json is an abstract base class")
 
 public:
 	explicit Json(QObject* parent = nullptr) : QObject(parent) {}

--- a/src/qmlbinding/json_internals/json_t_impl.h
+++ b/src/qmlbinding/json_internals/json_t_impl.h
@@ -89,6 +89,9 @@ void JsonT<LCFTYPE>::set(QString jsonPtr, const QVariant& value) {
 		case QMetaType::Int:
 			glz::set(m_data, jsonPtr.toStdString(), value.toInt());
 			break;
+		case QMetaType::Double:
+			glz::set(m_data, jsonPtr.toStdString(), value.toDouble());
+			break;
 		case QMetaType::QString: {
 			lcf::DBString s = ToDBString(value.value<QString>());
 			glz::set(m_data, jsonPtr.toStdString(), s);

--- a/src/qmlbinding/json_internals/json_t_impl.h
+++ b/src/qmlbinding/json_internals/json_t_impl.h
@@ -47,10 +47,22 @@ QString JsonT<LCFTYPE>::str(QString jsonPtr) const {
 
 template<typename LCFTYPE>
 int JsonT<LCFTYPE>::num(QString jsonPtr) const {
-	auto res = glz::get<int>(*m_data, jsonPtr.toStdString());
+	std::string ptr = jsonPtr.toStdString();
 
-	if (res) {
-		return res.value();
+	if (auto res = glz::get<int32_t>(*m_data, ptr)) {
+		return res.value().get();
+	}
+
+	if (auto res = glz::get<uint32_t>(*m_data, ptr)) {
+		return static_cast<int>(res.value().get());
+	}
+
+	if (auto res = glz::get<int16_t>(*m_data, ptr)) {
+		return static_cast<int>(res.value().get());
+	}
+
+	if (auto res = glz::get<uint16_t>(*m_data, ptr)) {
+		return static_cast<int>(res.value().get());
 	}
 
 	qDebug() << "Json::num: Not pointing to int: " << jsonPtr;
@@ -87,14 +99,14 @@ void JsonT<LCFTYPE>::set(QString jsonPtr, const QVariant& value) {
 			break;
 		}
 		default:
-			assert(false);
+			qDebug() << "Json::set: Type unsupported: " << value.typeName();
 			break;
 	}
 }
 
 template <typename T>
 concept IsVector = requires {
-    typename T::value_type;
+	typename T::value_type;
 } && std::is_class_v<typename T::value_type>;
 
 template<typename LCFTYPE>

--- a/src/qmlbinding/json_list_view.cpp
+++ b/src/qmlbinding/json_list_view.cpp
@@ -22,8 +22,8 @@ QHash<int, QByteArray> JsonListView::roleNames() const {
 	roles[Qt::DisplayRole] = "display";
     roles[NameRole] = "name";
     roles[TitleRole] = "title";
-	roles[IdRole] = "index";
-	roles[IndexRole] = "listindex";
+	roles[IdRole] = "identifier";
+	roles[IndexRole] = "index";
     return roles;
 }
 

--- a/src/qmlbinding/json_list_view.cpp
+++ b/src/qmlbinding/json_list_view.cpp
@@ -19,10 +19,10 @@
 
 QHash<int, QByteArray> JsonListView::roleNames() const {
     QHash<int, QByteArray> roles;
-	roles[Qt::DisplayRole] = "display";
+	roles[Qt::DisplayRole] = "text";
     roles[NameRole] = "name";
     roles[TitleRole] = "title";
-	roles[IdRole] = "identifier";
+	roles[IdRole] = "value";
 	roles[IndexRole] = "index";
     return roles;
 }

--- a/src/qmlbinding/json_list_view.h
+++ b/src/qmlbinding/json_list_view.h
@@ -28,6 +28,8 @@
 class JsonListView : public QAbstractListModel {
 	Q_OBJECT
 	QML_ELEMENT
+	Q_PROPERTY(int fallbackValue MEMBER m_fallbackValue NOTIFY fallbackValueChanged)
+	Q_PROPERTY(QString fallbackString MEMBER m_fallbackString NOTIFY fallbackStringChanged)
 
 public:
 	enum RoleNames {
@@ -59,11 +61,19 @@ public:
 	JsonView* view() const { return m_view; }
 	void setView(JsonView* view) { m_view = view; }
 
+	bool hasFallback() const {
+		return !m_fallbackString.isEmpty();
+	}
+
 signals:
 	void dataChanged();
+	void fallbackValueChanged();
+	void fallbackStringChanged();
 
 protected:
 	JsonView* m_view = nullptr;
+	int m_fallbackValue = 0;
+	QString m_fallbackString;
 };
 
 template<typename LCFTYPE>
@@ -82,14 +92,13 @@ public:
 	std::vector<LCFTYPE>* data() const { return m_data; }
 	void setData(std::vector<LCFTYPE>* data) { m_data = data; }
 
-
 private:
 	std::vector<LCFTYPE>* m_data = nullptr;
 };
 
 template<typename LCFTYPE>
 inline int JsonListViewT<LCFTYPE>::rowCount(const QModelIndex &parent) const {
-	return m_data->size();
+	return m_data->size() + (hasFallback() ? 1 : 0);
 }
 
 template<typename LCFTYPE>
@@ -98,7 +107,6 @@ inline QVariant JsonListViewT<LCFTYPE>::data(const QModelIndex &index, int role)
 	    return QVariant();
 	}
 
-	QVariant value;
 	std::string role_str;
 
 	switch (role) {
@@ -116,27 +124,43 @@ inline QVariant JsonListViewT<LCFTYPE>::data(const QModelIndex &index, int role)
 		case Qt::DisplayRole: {
 			auto id = data(index, IdRole);
 			auto name = data(index, NameRole);
-			auto s = QString("%1: %2").arg(id.toInt(), 4, u'0').arg(name.toString());
-			qDebug() << s;
+			auto s = QString("%1: %2").arg(id.toInt(), 4, 10, u'0').arg(name.toString());
 			return QVariant::fromValue(s);
 		}
 		default:
 			return QVariant();
 	}
 
-	role_str = std::format("/{}/{}", index.row(), role_str);
+	if (hasFallback() && index.row() == 0) {
+		switch (role) {
+			case NameRole:
+				return QVariant::fromValue(m_fallbackString);
+			case IdRole:
+				return QVariant::fromValue(m_fallbackValue);
+			default:
+				return {};
+		}
+	}
+
+	// Shift row back in case of fallback
+	int row = index.row();
+	if (hasFallback()) {
+		--row;
+	}
+
+	role_str = std::format("/{}/{}", row, role_str);
 
 	auto res = glz::get<lcf::DBString>(*m_data, role_str);
 	if (res.has_value()) {
-		value = QVariant::fromValue(ToQString(res.value()));
+		return QVariant::fromValue(ToQString(res.value()));
 	}
 
 	auto res2 = glz::get<int>(*m_data, role_str);
 	if (res2.has_value()) {
-		value = QVariant::fromValue(res2.value());
+		return QVariant::fromValue(res2.value().get());
 	}
 
-	return value;
+	return {};
 }
 
 template<typename LCFTYPE>

--- a/src/qmlbinding/project_data_gadget.cpp
+++ b/src/qmlbinding/project_data_gadget.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "project_data_gadget.h"
+#include "model/actor.h"
 #include "model/project.h"
 #include "json_view.h"
 
@@ -37,9 +38,6 @@ void ProjectDataGadget::setProjectData(ProjectData* data) {
 }
 
 JsonView* ProjectDataGadget::database() {
-	auto res = m_database_json.subtree("/");
-	qDebug() << "database() " << m_data << " " << res;
-
     return m_data ? qvariant_cast<JsonView*>(m_database_json.subtree("/")) : nullptr;
 }
 
@@ -65,6 +63,10 @@ QString ProjectDataGadget::findDirectory(const QString& dir) const {
 
 QString ProjectDataGadget::findDirectory(const QString& baseDir, const QString& dir) const {
 	return m_data->project().findDirectory(baseDir, dir);
+}
+
+ActorModel ProjectDataGadget::actorModel(int actor_index) {
+	return ActorModel(*m_data, m_data->database().actors[actor_index]);
 }
 
 QString ProjectDataGadget::projectPath() const {

--- a/src/qmlbinding/project_data_gadget.h
+++ b/src/qmlbinding/project_data_gadget.h
@@ -23,6 +23,7 @@
 #include <lcf/rpg/fwd.h>
 #include <QObject>
 
+class ActorModel;
 class JsonView;
 
 /**
@@ -48,6 +49,8 @@ public:
     Q_INVOKABLE QString findFileOrDefault(const QString& filename);
     Q_INVOKABLE QString findDirectory(const QString& dir) const;
     Q_INVOKABLE QString findDirectory(const QString& baseDir, const QString& dir) const;
+
+	Q_INVOKABLE ActorModel actorModel(int actor_index);
 
 	QString projectPath() const;
 

--- a/src/ui/common/CheckBox.qml
+++ b/src/ui/common/CheckBox.qml
@@ -12,9 +12,8 @@ Controls.CheckBox {
     property Ez.JsonView jsonData
 
     onToggled: {
-    	//console.log("Text changed to:", text)
     	if (jsonData !== null && key !== "") {
-    		jsonData.set(key, checkState);
+    		jsonData.set(key, checked);
     	}
     }
 
@@ -23,6 +22,10 @@ Controls.CheckBox {
     }
 
     function onDataChanged() {
-    	checkState = (jsonData.boolean(key));
+    	if (jsonData !== null && key !== "") {
+    		checked = jsonData.boolean(key);
+    	} else {
+    		checked = false;
+    	}
     }
 }

--- a/src/ui/common/ComboBox.qml
+++ b/src/ui/common/ComboBox.qml
@@ -9,10 +9,10 @@ Controls.ComboBox {
     id: root
 
     property string key
-    property Ez.JsonView jsonData
+    property var jsonData
 
-    textRole: "display"
-    valueRole: "identifier"
+    textRole: "text" // In a JsonListView this is "ID: NAME", e.g. "0001: Aina"
+    valueRole: "value" // In a JsonListView is the "ID"
 
     onActivated: {
         if (jsonData !== null && key !== "") {
@@ -28,7 +28,7 @@ Controls.ComboBox {
         if (jsonData !== null && key !== "") {
             currentIndex = indexOfValue(jsonData.num(key))
             if (currentIndex === -1) {
-                console.log(`ComboBox: ${jsonData.num(key)} not found for ${key} ${root.model.fallbackString}`);
+                console.log(`ComboBox: ${jsonData.num(key)} not found for ${key}`);
 
                 let isProxy = (root.model.sourceModel !== undefined);
                 let model = isProxy ? root.model.sourceModel : root.model;

--- a/src/ui/common/ComboBox.qml
+++ b/src/ui/common/ComboBox.qml
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: EasyRPG Editor Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls as Controls
+import org.easyrpg.editor as Ez
+
+Controls.ComboBox {
+    id: root
+
+    property string key
+    property Ez.JsonView jsonData
+
+    textRole: "display"
+    valueRole: "identifier"
+
+    property string fallbackString: ""
+
+    onActivated: {
+        if (jsonData !== null && key !== "") {
+            jsonData.set(key, currentValue)
+        }
+    }
+
+    Component.onCompleted: {
+        onDataChanged()
+    }
+
+    function onDataChanged() {
+        if (jsonData !== null && key !== "") {
+            currentIndex = indexOfValue(jsonData.num(key))
+            if (currentIndex === -1) {
+                console.log("Warning: Value " + jsonData.num(key) + " not found in ComboBox model for key " + key)
+            }
+        }
+    }
+
+    onModelChanged: applyFallbackString()
+    onFallbackStringChanged: applyFallbackString()
+
+    function applyFallbackString() {
+        root.model.fallbackString = root.fallbackString
+    }
+}

--- a/src/ui/common/ComboBox.qml
+++ b/src/ui/common/ComboBox.qml
@@ -14,8 +14,6 @@ Controls.ComboBox {
     textRole: "display"
     valueRole: "identifier"
 
-    property string fallbackString: ""
-
     onActivated: {
         if (jsonData !== null && key !== "") {
             jsonData.set(key, currentValue)
@@ -30,15 +28,15 @@ Controls.ComboBox {
         if (jsonData !== null && key !== "") {
             currentIndex = indexOfValue(jsonData.num(key))
             if (currentIndex === -1) {
-                console.log("Warning: Value " + jsonData.num(key) + " not found in ComboBox model for key " + key)
+                console.log(`ComboBox: ${jsonData.num(key)} not found for ${key} ${root.model.fallbackString}`);
+
+                let isProxy = (root.model.sourceModel !== undefined);
+                let model = isProxy ? root.model.sourceModel : root.model;
+
+                if (model.fallbackString !== "") {
+                    currentIndex = indexOfValue(model.fallbackValue);
+                }
             }
         }
-    }
-
-    onModelChanged: applyFallbackString()
-    onFallbackStringChanged: applyFallbackString()
-
-    function applyFallbackString() {
-        root.model.fallbackString = root.fallbackString
     }
 }

--- a/src/ui/common/RadioButton.qml
+++ b/src/ui/common/RadioButton.qml
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: EasyRPG Editor Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls as Controls
+import org.easyrpg.editor as Ez
+
+Controls.RadioButton {
+    id: root
+
+    property string key
+    property Ez.JsonView jsonData
+
+    property int value
+
+    onCheckedChanged: {
+        if (checked && jsonData !== null && key !== "") {
+            jsonData.set(key, value)
+        }
+    }
+
+    Component.onCompleted: {
+        onDataChanged()
+    }
+
+    function onDataChanged() {
+        checked = (jsonData.num(key) === value)
+    }
+}

--- a/src/ui/common/SpinBox.qml
+++ b/src/ui/common/SpinBox.qml
@@ -11,6 +11,9 @@ Controls.SpinBox {
     property string key
     property Ez.JsonView jsonData
 
+    property string prefix: ""
+    property string suffix: ""
+
     onValueChanged: {
         if (jsonData !== null && key !== "") {
             jsonData.set(key, value)
@@ -23,5 +26,21 @@ Controls.SpinBox {
 
     function onDataChanged() {
         value = jsonData.num(key)
+    }
+
+    textFromValue: function(value, locale) {
+        return prefix + Number(value).toLocaleString(locale, 'f', 0) + suffix;
+    }
+
+    valueFromText: function(text, locale) {
+        if (prefix !== "" && text.startsWith(prefix)) {
+            text = text.substring(prefix.length);
+        }
+
+        if (suffix !== "" && text.endsWith(suffix)) {
+            text = text.substring(0, text.length - suffix.length);
+        }
+
+        return Number.fromLocaleString(locale, text);
     }
 }

--- a/src/ui/common/rpg_model.h
+++ b/src/ui/common/rpg_model.h
@@ -26,6 +26,7 @@
 #include "common/dbstring.h"
 #include "common/filefinder.h"
 #include "common/image_loader.h"
+#include "json_list_view.h"
 #include "model/rpg_reflect.h"
 
 template<typename LCF>
@@ -62,7 +63,7 @@ QVariant RpgModel<LCF>::data(const QModelIndex &index, int role) const {
 		return QString("%1: %2").arg(data.ID, 4, 10, QChar('0')).arg(ToQString(data.name));
 	} else if (role == Qt::DecorationRole) {
 		return typename RpgReflect<LCF>::model_type(m_project, m_data[index.row()]).preview();
-	} else if (role == Qt::UserRole) {
+	} else if (role == Qt::UserRole || role == JsonListView::IdRole) {
 		return m_data[index.row()].ID;
 	} else if (role == ModelDataObject) {
 		return QVariant::fromValue(&m_data[index.row()]);

--- a/src/ui/common/system_color_combobox.cpp
+++ b/src/ui/common/system_color_combobox.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "system_color_combobox.h"
+#include "common/image_loader.h"
 
 SystemColorComboBox::SystemColorComboBox(QWidget *parent) : QComboBox(parent) {}
 

--- a/src/ui/database/ActorPage.qml
+++ b/src/ui/database/ActorPage.qml
@@ -68,5 +68,19 @@ DatabaseEntryPage {
                 enabled: critical_hit_cb.checked
             }
         }
+
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: "Equipment"
+        }
+
+        Ez.ComboBox {
+            jsonData: root.jsonData
+            key: "initial_equipment/weapon_id"
+            Kirigami.FormData.label: "Weapon Type:"
+            model: Ez.ProjectData.database().list("items")
+            fallbackString: "(None)"
+        }
     }
 }

--- a/src/ui/database/ActorPage.qml
+++ b/src/ui/database/ActorPage.qml
@@ -12,6 +12,15 @@ import org.easyrpg.editor as Ez
 DatabaseEntryPage {
     id: root
 
+    Models.ListModel {
+        id: equipmentModel
+        Models.ListElement { key: "weapon_id"; label: "Weapon:"; type: 1 }
+        Models.ListElement { key: "shield_id"; label: "Shield:"; type: 2 }
+        Models.ListElement { key: "armor_id"; label: "Armor:"; type: 3 }
+        Models.ListElement { key: "helmet_id"; label: "Helmet:"; type: 4 }
+        Models.ListElement { key: "accessory_id"; label: "Accessory:"; type: 5 }
+    }
+
     Kirigami.FormLayout {
         anchors.fill: parent
 
@@ -69,18 +78,29 @@ DatabaseEntryPage {
             }
         }
 
-
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Kirigami.FormData.label: "Equipment"
         }
 
-        Ez.ComboBox {
-            jsonData: root.jsonData
-            key: "initial_equipment/weapon_id"
-            Kirigami.FormData.label: "Weapon Type:"
-            model: Ez.ProjectData.database().list("items")
-            fallbackString: "(None)"
+        Repeater {
+            id: equipmentRepeater
+            model: equipmentModel
+
+            Ez.ComboBox {
+                readonly property var repdata: equipmentRepeater.model.get(index)
+
+                jsonData: root.jsonData
+                key: "initial_equipment/" + repdata.key
+                Kirigami.FormData.label: repdata.label
+                model: {
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(repdata.type);
+                    let list = Ez.ProjectData.database().list("items");
+                    list.fallbackString = "(None)";
+                    filter.sourceModel = list;
+                    return filter;
+                }
+            }
         }
     }
 }

--- a/src/ui/database/AttributePage.qml
+++ b/src/ui/database/AttributePage.qml
@@ -62,6 +62,7 @@ DatabaseEntryPage {
                 Kirigami.FormData.label: model.label
                 from: -9999
                 to: 9999
+                suffix: "%"
             }
         }
     }

--- a/src/ui/database/AttributePage.qml
+++ b/src/ui/database/AttributePage.qml
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: EasyRPG Editor Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls as Controls
+import QtQuick.Dialogs as Dialogs
+import QtQml.Models as Models
+import org.kde.kirigami as Kirigami
+import org.easyrpg.editor as Ez
+
+DatabaseEntryPage {
+    id: root
+
+    Models.ListModel {
+        id: rateModel
+        Models.ListElement { key: "a_rate"; label: "A Rate:" }
+        Models.ListElement { key: "b_rate"; label: "B Rate:" }
+        Models.ListElement { key: "c_rate"; label: "C Rate:" }
+        Models.ListElement { key: "d_rate"; label: "D Rate:" }
+        Models.ListElement { key: "e_rate"; label: "E Rate:" }
+    }
+
+    Kirigami.FormLayout {
+        anchors.fill: parent
+
+        Ez.TextField {
+            jsonData: root.jsonData
+            key: "name"
+            Kirigami.FormData.label: "Name:"
+        }
+
+        ColumnLayout {
+            Kirigami.FormData.label: "Attribute Type:"
+            Kirigami.FormData.buddyFor: radio_physical
+            Ez.RadioButton {
+                id: radio_physical
+                jsonData: root.jsonData
+                key: "type"
+                text: "Physical"
+                value: 0
+            }
+            Ez.RadioButton {
+                jsonData: root.jsonData
+                key: "type"
+                text: "Magical"
+                value: 1
+            }
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: "Damage Multipliers"
+        }
+
+        Repeater {
+            model: rateModel
+
+            Ez.SpinBox {
+                jsonData: root.jsonData
+                key: model.key
+                Kirigami.FormData.label: model.label
+                from: -9999
+                to: 9999
+            }
+        }
+    }
+}

--- a/src/ui/database/DatabaseEntryListPage.qml
+++ b/src/ui/database/DatabaseEntryListPage.qml
@@ -33,17 +33,17 @@ Kirigami.ScrollablePage {
         }
 
         delegate: Controls.ItemDelegate {
-            required property int listindex
+            required property int index
             required property string name
 
     		width: ListView.view.width
-            text: (listindex+1).toString().padStart(4, '0') + ": " + name
+            text: (index+1).toString().padStart(4, '0') + ": " + name
 
-            highlighted: entryList.currentIndex === listindex
+            highlighted: entryList.currentIndex === index
 
             action: Controls.Action {
                 onTriggered: {
-                    entryList.currentIndex = listindex
+                    entryList.currentIndex = index
                 }
             }
         }

--- a/src/ui/database/DatabaseEntryListPage.qml
+++ b/src/ui/database/DatabaseEntryListPage.qml
@@ -65,7 +65,8 @@ Kirigami.ScrollablePage {
             //console.log("Pushing:", root.targetPage);
             pageStack.push(Qt.resolvedUrl(root.targetPage), {
                 // Use the index passed to the function
-                jsonData: jsonData.subtree("/" + index)
+                jsonData: jsonData.subtree("/" + index),
+                objIndex: index
             });
         }
     }

--- a/src/ui/database/DatabaseEntryPage.qml
+++ b/src/ui/database/DatabaseEntryPage.qml
@@ -18,6 +18,9 @@ Kirigami.ScrollablePage {
     Kirigami.ColumnView.fillWidth: true
     Kirigami.ColumnView.reservedSpace: applicationWindow().pageStack.defaultColumnWidth * (applicationWindow().pageStack.depth - 1)
 
+    /** When the object comes from a list, contains the index. Otherwise -1. */
+    property int objIndex: -1
+
     // TODO: Not used. Just for testing
     property bool showActions: false
 

--- a/src/ui/database/DatabasePage.qml
+++ b/src/ui/database/DatabasePage.qml
@@ -42,6 +42,11 @@ Kirigami.ScrollablePage {
             targetPage: "SkillPage.qml"
         }
         ListElement {
+            name: "Attributes"
+            key: "attributes"
+            targetPage: "AttributePage.qml"
+        }
+        ListElement {
             name: "Vocabulary"
             key: "terms"
             single: true

--- a/src/ui/database/SkillPage.qml
+++ b/src/ui/database/SkillPage.qml
@@ -4,25 +4,42 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls as Controls
+import QtQml.Models as Models
 import org.kde.kirigami as Kirigami
 import org.easyrpg.editor as Ez
 
 DatabaseEntryPage {
     id: root
 
+    Models.ListModel {
+        id: typeModel
+        Models.ListElement { value: 0; text: "Normal" }
+        Models.ListElement { value: 1; text: "Teleport" }
+        Models.ListElement { value: 2; text: "Escape" }
+        Models.ListElement { value: 3; text: "Switch" }
+    }
+
     Kirigami.FormLayout {
         anchors.fill: parent
 
-    	Ez.TextField {
-    		jsonData: root.jsonData
-    		key: "name"
-    		Kirigami.FormData.label: "Name:"
-    	}
+        Ez.TextField {
+            jsonData: root.jsonData
+            key: "name"
+            Kirigami.FormData.label: "Name:"
+        }
 
-    	Ez.TextField {
-    		jsonData: root.jsonData
-    		key: "description"
-    		Kirigami.FormData.label: "Description:"
-    	}
+        Ez.TextField {
+            jsonData: root.jsonData
+            key: "description"
+            Kirigami.FormData.label: "Description:"
+        }
+
+        Ez.ComboBox {
+            id: cbType
+            jsonData: root.jsonData
+            key: "type"
+            Kirigami.FormData.label: "Type: "
+            model: typeModel
+        }
     }
 }

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -241,7 +241,7 @@ void ActorWidget::on_currentActorChanged(lcf::rpg::Actor *actor)
 
 	auto equipFilter = [&](auto& cbox, auto type) {
 		SignalBlocker s(cbox->comboBox());
-		cbox->setFilter(static_cast<QSortFilterProxyModel*>(ActorModel(m_project, *m_current).CreateEquipmentFilter(type)));
+		cbox->setFilter(static_cast<QSortFilterProxyModel*>(ActorModel(m_project, *m_current).CreateEquipmentFilter(type, this)));
 	};
 
 	equipFilter(ui->comboInitialWeapon, lcf::rpg::Item::Type_weapon);

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -241,7 +241,7 @@ void ActorWidget::on_currentActorChanged(lcf::rpg::Actor *actor)
 
 	auto equipFilter = [&](auto& cbox, auto type) {
 		SignalBlocker s(cbox->comboBox());
-		cbox->setFilter(ActorModel(m_project, *m_current).CreateEquipmentFilter(type));
+		cbox->setFilter(static_cast<QSortFilterProxyModel*>(ActorModel(m_project, *m_current).CreateEquipmentFilter(type)));
 	};
 
 	equipFilter(ui->comboInitialWeapon, lcf::rpg::Item::Type_weapon);


### PR DESCRIPTION
Another PR to show that the editor is not dead again :P.

Notable changes are:

A fully working Attributes Page (RM calls this Elements). Not that this page is very useful but it was a good test case for implementing `Ez.RadioButton` (+ JSON binding) and learning about `Repeater`.

<img width="530" height="350" alt="grafik" src="https://github.com/user-attachments/assets/30c0bcdf-488d-4cd9-a864-176196492c8d" />

`Ez.ComboBox` with support of binding to a `JsonList` (ignore the mixed width of the Comboboxes, I'll fix layout issues later). The nice part: For the equipment I was able to reuse the "IdListFilter" that was already used to filter in the QWidgets Database.

The JsonList can contain now an optional "None" element.

<img width="280" height="214" alt="grafik" src="https://github.com/user-attachments/assets/74c37bca-9ae8-4d8c-ad23-3da28f58d0f9" />

And besides `JsonList` it can also bind to a normal value+text model.

<img width="296" height="241" alt="grafik" src="https://github.com/user-attachments/assets/389797c3-da75-4b55-bcd7-74ac1c27f7e5" />

Rest is mostly cleanup and bugfixes (the `.clangd` is the config file for clangd used by multiple IDEs). The default config doesn't work, probably Qt pulling in some weird flags.

