### PR TITLE
Set macosx sysroot in the presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -263,7 +263,8 @@
 			"cacheVariables": {
 				"EDITOR_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/macos/qt/6.10.1/macos",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "13.3",
-				"CMAKE_OSX_ARCHITECTURES": "arm64"
+				"CMAKE_OSX_ARCHITECTURES": "arm64",
+				"CMAKE_OSX_SYSROOT": "macosx"
 			},
 			"environment": {
 				"Qt6_Path": "$env{EASYRPG_BUILDSCRIPTS}/macos/qt/6.10.1/macos"

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -40,7 +40,8 @@
 			"cacheVariables": {
 				"EDITOR_PREFIX_PATH_APPEND": "$env{EASYRPG_BUILDSCRIPTS}/macos/qt/6.10.1/macos",
 				"CMAKE_OSX_DEPLOYMENT_TARGET": "13.3",
-				"CMAKE_OSX_ARCHITECTURES": "arm64"
+				"CMAKE_OSX_ARCHITECTURES": "arm64",
+				"CMAKE_OSX_SYSROOT": "macosx"
 			},
 			"environment": {
 				"Qt6_Path": "$env{EASYRPG_BUILDSCRIPTS}/macos/qt/6.10.1/macos"


### PR DESCRIPTION
Otherwise this breaks with CMake 4.0 which will pick the wrong SDK version


For liblcf and Player I fixed this manually for now in the Jenkins settings.

The Editor Jenkins stuff is more modern and uses the presets already.