### PR TITLE
Use GridLaneLayout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,9 +323,11 @@ set(EDITOR_SOURCES
 )
 
 set(EDITOR_QML_UI
+	src/ui/common/Card.qml
 	src/ui/common/CheckBox.qml
 	src/ui/common/ComboBox.qml
 	src/ui/common/FormLayout.qml
+	src/ui/common/GridLaneLayout.qml
 	src/ui/common/PickerData.qml
 	src/ui/common/RadioButton.qml
 	src/ui/common/SpinBox.qml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ set(EDITOR_SOURCES
 set(EDITOR_QML_UI
 	src/ui/common/CheckBox.qml
 	src/ui/common/ComboBox.qml
+	src/ui/common/FormLayout.qml
 	src/ui/common/PickerData.qml
 	src/ui/common/RadioButton.qml
 	src/ui/common/SpinBox.qml

--- a/README.adoc
+++ b/README.adoc
@@ -25,9 +25,16 @@ https://wiki.easyrpg.org
 == Requirements
 
 - {liblcf} for RPG Maker data reading.
-- {qt6} (>= 6.10)
-- Qt Multimedia
-- Qt SVG
+- {qt6} (>= 6.10.1) (Widgets, QtQuick/QML, Multimedia and SVG)
+- ECM for additional CMake functionality.
+- Kirigami for additional QML Widgets.
+- QQC2 Breeze Style for QML styling.
+- KDDockWidgets for floating windows and docking.
+- zlib for XYZ image support.
+- Glaze for converting LCF data to JSON and binding to QML.
+
+Optional dependencies:
+
 - Qt Linguist (optional, for translation)
 
 == Daily builds
@@ -54,15 +61,35 @@ https://easyrpg.org/downloads/editor/
 
 Building requirements:
 
-- CMake >= 3.15
+- A C++23 capable compiler.
+- CMake >= 3.15 (>= 3.23 to use the provided CMake presets)
 
 Step-by-step instructions:
 
 [source,shell]
 ---------------------------------------
-cmake .          # generate Makefile
-cmake --build .  # compile the executable
+cmake -S . -B build   # generate the build system
+cmake --build build   # compile the executable
 ---------------------------------------
+
+Another option is to use CMake presets:
+
+---------------------------------------
+cmake --preset TYPE          # generate the build system
+cmake --build --preset TYPE  # compile the executable
+---------------------------------------
+
+Possible values for `TYPE` are `debug`, `relwithdebinfo` and `release`.
+
+If liblcf is not installed on the system, either add `-DEDITOR_BUILD_LIBLCF=ON`
+to the configure step to build it as part of the project, or use one of the
+`liblcf-TYPE` presets (e.g. `liblcf-debug`).
+
+The non-Qt dependencies can be installed and built automatically with vcpkg.
+This requires vcpkg to be installed and the `VCPKG_ROOT` environment variable
+to be set to its installation directory. Due to its sheer size, Qt6 itself is
+not managed by vcpkg and must still be provided separately (e.g. as a system
+package). The corresponding presets are `vcpkg-TYPE` and `vcpkg-liblcf-TYPE`.
 
 
 == Running EasyRPG Editor

--- a/src/ui/common/Card.qml
+++ b/src/ui/common/Card.qml
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: EasyRPG Editor Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.easyrpg.editor as Ez
+
+/**
+ * Card layout with a preconfigured heading and a Form Layout
+ */
+Kirigami.Card {
+    id: root
+
+    property string title: ""
+    default property alias cardChildren: formLayout.data
+
+    Layout.fillWidth: true
+    Layout.alignment: Qt.AlignTop
+
+    // Override the default background to improve the contrast
+    background: Rectangle {
+        color: Qt.alpha(Kirigami.Theme.backgroundColor, 0.5)
+        radius: Kirigami.Units.smallSpacing
+        border.color: Qt.alpha(Kirigami.Theme.textColor, 0.15)
+        border.width: 1
+    }
+
+    header: Kirigami.Heading {
+        text: root.title
+        level: 2
+        visible: text.length > 0
+    }
+
+    contentItem: Ez.FormLayout {
+        id: formLayout
+    }
+}

--- a/src/ui/common/FormLayout.qml
+++ b/src/ui/common/FormLayout.qml
@@ -1,0 +1,493 @@
+/*
+ *  SPDX-FileCopyrightText: 2017 Marco Martin <mart@kde.org>
+ *  SPDX-FileCopyrightText: 2022 ivan tkachenko <me@ratijas.tk>
+ *  SPDX-FileCopyrightText: EasyRPG Editor Authors
+ *
+ *  SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Templates as T
+import org.kde.kirigami as Kirigami
+
+/*
+Vendored Kirigami Form Layout to make small adjustments possible
+The Form Layout is not designed by default for dense UIs like our Editor
+*/
+
+/*!
+  \qmltype FormLayout
+  \inqmlmodule org.kde.kirigami.layouts
+
+  \brief The base class for Form layouts conforming to the
+  Kirigami Human Interface Guidelines.
+
+  The layout consists of two columns:
+  the left column contains only right-aligned
+  labels provided by a FormData attached property,
+  the right column contains left-aligned child types.
+
+  Child types can be sectioned using an QtQuick.Item
+  or Kirigami.Separator with a FormData
+  attached property, see FormLayoutAttached::isSection for details.
+
+  Example usage:
+  \qml
+  import QtQuick.Controls as QQC2
+  import org.kde.kirigami as Kirigami
+
+  Kirigami.FormLayout {
+     QQC2.TextField {
+        Kirigami.FormData.label: "Label:"
+     }
+     Kirigami.Separator {
+         Kirigami.FormData.label: "Section Title"
+         Kirigami.FormData.isSection: true
+     }
+     QQC2.TextField {
+        Kirigami.FormData.label: "Label:"
+     }
+     QQC2.TextField {
+     }
+  }
+  \endqml
+  \sa FormData
+  \since 2.3
+ */
+Item {
+    id: root
+
+    /*!
+      \brief This property tells whether the form layout is in wide mode.
+
+      If true, the layout will be optimized for a wide screen, such as
+      a desktop machine (the labels will be on a left column,
+      the fields on a right column beside it), if false (such as on a phone)
+      everything is laid out in a single column.
+
+      By default this property automatically adjusts the layout
+      if there is enough screen space.
+
+      Set this to \c true for a convergent design,
+      set this to \c false for a mobile-only design.
+     */
+    property bool wideMode: false // EasyRPG Modification: Force mobile layout (Labels always above controls)
+
+    /*!
+      If for some implementation reason multiple FormLayouts have to appear
+      on the same page, they can have each other in twinFormLayouts,
+      so they will vertically align with each other perfectly
+
+      \since 5.53
+     */
+    property list<Item> twinFormLayouts  // should be list<FormLayout> but we can't have a recursive declaration
+
+    onTwinFormLayoutsChanged: {
+        for (const twinFormLayout of twinFormLayouts) {
+            if (!(root in twinFormLayout.children[0].reverseTwins)) {
+                twinFormLayout.children[0].reverseTwins.push(root)
+                Qt.callLater(() => twinFormLayout.children[0].reverseTwinsChanged());
+            }
+        }
+    }
+
+    property Kirigami.ScrollablePage scrollablePage: findAncestor(root, (item) => item instanceof Kirigami.ScrollablePage) as Kirigami.ScrollablePage
+
+    function findAncestor(item: Item, predicate: /*function Item => bool*/ var): Item {
+        let target = item.parent
+        while (target && !predicate(target)) {
+            target = target.parent
+        }
+        return target
+    }
+
+    function ensureVisible(item: Item): void {
+        if (item && root.scrollablePage) {
+            const itemPosition = scrollablePage.flickable.contentItem.mapFromItem(item, 0, 0)
+            root.scrollablePage.ensureVisible(item, itemPosition.x - item.x, itemPosition.y - item.y)
+        }
+    }
+
+    Connections {
+        target: root.Window
+        enabled: root.scrollablePage
+        function onActiveFocusItemChanged(): void {
+            if (root.Window.activeFocusItem && root.findAncestor(root.Window.activeFocusItem, (item) => item === root)) {
+                root.ensureVisible(root.Window.activeFocusItem)
+            }
+        }
+    }
+
+    Component.onDestruction: {
+        for (const twinFormLayout of twinFormLayouts) {
+            const child = twinFormLayout.children[0];
+            child.reverseTwins = child.reverseTwins.filter(value => value !== root);
+        }
+    }
+
+    implicitWidth: lay.wideImplicitWidth
+    implicitHeight: lay.implicitHeight
+    Layout.preferredHeight: lay.implicitHeight
+    Layout.fillWidth: true
+    Accessible.role: Accessible.Form
+
+    GridLayout {
+        id: lay
+        property int wideImplicitWidth
+        columns: root.wideMode ? 2 : 1
+        rowSpacing: Kirigami.Units.smallSpacing
+        columnSpacing: Kirigami.Units.largeSpacing
+
+        width: root.width // EasyRPG Modification: Use full width
+        anchors.horizontalCenter: root.horizontalCenter
+
+        property var reverseTwins: []
+        property var knownItems: []
+        property var buddies: []
+        property int knownItemsImplicitWidth: {
+            let hint = 0;
+            for (const item of knownItems) {
+                if (typeof item.Layout === "undefined") {
+                    // Items may have been dynamically destroyed. Even
+                    // printing such zombie wrappers results in a
+                    // meaningless "TypeError: Type error". Normally they
+                    // should be cleaned up from the array, but it would
+                    // trigger a binding loop if done here.
+                    //
+                    // This is, so far, the only way to detect them.
+                    continue;
+                }
+                const actualWidth = item.Layout.preferredWidth > 0
+                    ? item.Layout.preferredWidth
+                    : item.implicitWidth;
+
+                hint = Math.max(hint, item.Layout.minimumWidth, Math.min(actualWidth, item.Layout.maximumWidth));
+            }
+            return hint;
+        }
+        property int buddiesImplicitWidth: {
+            let hint = 0;
+
+            for (const buddy of buddies) {
+                if (buddy.visible && buddy.item !== null && !buddy.item.Kirigami.FormData.isSection) {
+                    hint = Math.max(hint, buddy.implicitWidth);
+                }
+            }
+            return hint;
+        }
+        readonly property var actualTwinFormLayouts: {
+            // We need to copy that array by value
+            const list = lay.reverseTwins.slice();
+            for (const parentLay of root.twinFormLayouts) {
+                if (!parentLay || !parentLay.hasOwnProperty("children")) {
+                    continue;
+                }
+                list.push(parentLay);
+                for (const childLay of parentLay.children[0].reverseTwins) {
+                    if (childLay && !(childLay in list)) {
+                        list.push(childLay);
+                    }
+                }
+            }
+            return list;
+        }
+
+        Timer {
+            id: hintCompression
+            interval: 0
+            onTriggered: {
+                if (root.wideMode) {
+                    lay.wideImplicitWidth = lay.implicitWidth;
+                }
+            }
+        }
+        onImplicitWidthChanged: hintCompression.restart();
+        //This invisible row is used to sync alignment between multiple layouts
+
+        Item {
+            id: leadingPlaceholder
+            Layout.preferredWidth: {
+                let hint = lay.buddiesImplicitWidth;
+                for (const item of lay.actualTwinFormLayouts) {
+                    if (item && item.hasOwnProperty("children")) {
+                        hint = Math.max(hint, item.children[0].buddiesImplicitWidth);
+                    }
+                }
+                return hint;
+            }
+            Layout.preferredHeight: 2
+        }
+        Item {
+            id: trailingPlaceholder
+            Layout.preferredWidth: {
+                let hint = Math.min(root.width, lay.knownItemsImplicitWidth);
+                for (const item of lay.actualTwinFormLayouts) {
+                    if (item.hasOwnProperty("children")) {
+                        hint = Math.max(hint, item.children[0].knownItemsImplicitWidth);
+                    }
+                }
+                return hint;
+            }
+            Layout.preferredHeight: 2
+        }
+    }
+
+    Item {
+        id: temp
+
+        /*!
+         * The following two functions are used in the label buddy items.
+         *
+         * They're in this mostly unused item to keep them private to the FormLayout
+         * without creating another QObject.
+         *
+         * Normally, such complex things in bindings are kinda bad for performance
+         * but this is a fairly static property. If for some reason an application
+         * decides to obsessively change its alignment, V8's JIT hotspot optimisations
+         * will kick in.
+         */
+
+        /*!
+         * @param {Item} item
+         * @returns {Qt::Alignment}
+         */
+        function effectiveLayout(item: Item): /*Qt.Alignment*/ int {
+            if (!item) {
+                return 0;
+            }
+            const verticalAlignment =
+                item.Kirigami.FormData.labelAlignment !== 0
+                ? item.Kirigami.FormData.labelAlignment
+                : Qt.AlignTop;
+
+            if (item.Kirigami.FormData.isSection) {
+                return Qt.AlignHCenter;
+            }
+            if (root.wideMode) {
+                return Qt.AlignRight | verticalAlignment;
+            }
+            return Qt.AlignLeft | Qt.AlignBottom;
+        }
+
+        /*!
+         * @param {Item} item
+         * @returns vertical alignment of the item passed as an argument.
+         */
+        function effectiveTextLayout(item: Item): /*Qt.Alignment*/ int {
+            if (!item) {
+                return 0;
+            }
+            if (root.wideMode && !item.Kirigami.FormData.isSection) {
+                return item.Kirigami.FormData.labelAlignment !== 0 ? item.Kirigami.FormData.labelAlignment : Text.AlignVCenter;
+            }
+            return Text.AlignBottom;
+        }
+    }
+
+    function relayout() {
+        const __items = root.children;
+        // exclude the layout and temp
+        let row = 0;
+        for (let i = 2; i < __items.length; ++i) {
+            const item = __items[i];
+
+            if (!(item instanceof Repeater)) {
+                item.Layout.row = row;
+                item.Layout.column = 1;
+                row += root.wideMode && !item.Kirigami.FormData.isSection ? 1 : 2;
+            }
+
+            // skip items that are already there
+            if (lay.knownItems.indexOf(item) !== -1 || item instanceof Repeater) {
+                continue;
+            }
+            lay.knownItems.push(item);
+
+            const itemContainer = itemComponent.createObject(lay, { item });
+            const buddy = buddyComponent.createObject(lay, { item, index: i - 2 });
+
+            lay.buddies.push(buddy);
+        }
+
+        leadingPlaceholder.Layout.row = row
+        leadingPlaceholder.Layout.column = 0
+        trailingPlaceholder.Layout.row = Qt.binding(() => row + (root.wideMode ? 0 : 1))
+        trailingPlaceholder.Layout.column = Qt.binding(() => root.wideMode ? 1 : 0)
+
+        lay.knownItemsChanged();
+        lay.buddiesChanged();
+        hintCompression.restart();
+    }
+
+    onChildrenChanged: relayout()
+    Component.onCompleted: {
+        relayout()
+        hintCompression.triggered()
+    }
+    onWideModeChanged: relayout()
+
+    Component {
+        id: itemComponent
+        Item {
+            id: container
+
+            property Item item
+
+            Layout.row: item?.Layout?.row + (root.wideMode && !item.Kirigami.FormData.isSection ? 0 : 1)
+            Layout.column: root.wideMode && !item?.Kirigami.FormData.isSection ? 1 : 0
+
+            enabled: item?.enabled ?? false
+            visible: item?.visible ?? false
+
+            // NOTE: work around a  GridLayout quirk which doesn't lay out items with null size hints causing things to be laid out incorrectly in some cases
+            implicitWidth: item !== null ? Math.max(item.implicitWidth, 1) : 0
+            implicitHeight: item !== null ? Math.max(item.implicitHeight, 1) : 0
+            Layout.preferredWidth: item !== null ? Math.max(1, item.Layout.preferredWidth > 0 ? item.Layout.preferredWidth : Math.ceil(item.implicitWidth)) : 0
+            Layout.preferredHeight: item !== null ? Math.max(1, item.Layout.preferredHeight > 0 ? item.Layout.preferredHeight : Math.ceil(item.implicitHeight)) : 0
+
+            Layout.minimumWidth: item?.Layout.minimumWidth ?? 0
+            Layout.minimumHeight: item?.Layout.minimumHeight ?? 0
+
+            Layout.maximumWidth: item?.Layout.maximumWidth ?? 0
+            Layout.maximumHeight: item?.Layout.maximumHeight ?? 0
+
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            Layout.fillWidth: item !== null && (item instanceof TextInput || item.Layout.fillWidth || item.Kirigami.FormData.isSection)
+            Layout.columnSpan: item?.Kirigami.FormData.isSection ? lay.columns : 1
+            onItemChanged: {
+                if (!item) {
+                    container.destroy();
+                }
+            }
+            onXChanged: if (item !== null) { item.x = x + lay.x; }
+            // Assume lay.y is always 0
+            onYChanged: if (item !== null) { item.y = y + lay.y; }
+            onWidthChanged: if (item !== null) { item.width = width; }
+            Component.onCompleted: item.x = x + lay.x;
+            Connections {
+                target: lay
+                function onXChanged(): void {
+                    if (container.item !== null) {
+                        container.item.x = container.x + lay.x;
+                    }
+                }
+            }
+        }
+    }
+    Component {
+        id: buddyComponent
+        Kirigami.Heading {
+            id: labelItem
+
+            property Item item
+            property int index
+
+            Layout.row: item?.Layout?.row
+            Layout.column: 0
+
+            enabled: {
+                const buddy = item?.Kirigami.FormData.buddyFor;
+                if (buddy) {
+                    return buddy.enabled;
+                } else {
+                    return item?.enabled ?? false;
+                }
+            }
+            visible: (item?.visible && (root.wideMode || text.length > 0)) ?? false
+            Kirigami.MnemonicData.enabled: {
+                const buddy = item?.Kirigami.FormData.buddyFor as Item;
+                if (buddy && buddy.enabled && buddy.visible && buddy.activeFocusOnTab) {
+                    // Only set mnemonic if the buddy doesn't already have one.
+                    const buddyMnemonic = buddy.Kirigami.MnemonicData;
+                    return !buddyMnemonic.label || !buddyMnemonic.enabled;
+                } else {
+                    return false;
+                }
+            }
+            Kirigami.MnemonicData.controlType: Kirigami.MnemonicData.FormLabel
+            Kirigami.MnemonicData.label: { // EasyRPG Modification: Append a ":" at the end of labels
+                const rawLabel = item?.Kirigami.FormData.label ?? "";
+                if (rawLabel.length > 0) {
+                    if (rawLabel.endsWith(":")) {
+                        throw new Error("Label must not end with a ':'!");
+                    } else if (!(item?.Kirigami.FormData.isSection ?? false)) {
+                        return rawLabel + ":";
+                    }
+                }
+                return rawLabel;
+            }
+            text: Kirigami.MnemonicData.richTextLabel
+            Accessible.name: Kirigami.MnemonicData.plainTextLabel
+            type: item?.Kirigami.FormData.isSection ? Kirigami.Heading.Type.Primary : Kirigami.Heading.Type.Normal
+
+            level: item?.Kirigami.FormData.isSection ? 3 : 5
+
+            Layout.columnSpan: item?.Kirigami.FormData.isSection ? lay.columns : 1
+            Layout.preferredHeight: {
+                if (!item) {
+                    return 0;
+                }
+                if (item.Kirigami.FormData.label.length > 0) {
+                    // Add extra whitespace before textual section headers, which
+                    // looks better than separator lines
+                    if (item.Kirigami.FormData.isSection && labelItem.index !== 0) {
+                        return implicitHeight + Kirigami.Units.largeSpacing * 2;
+                    }
+                    else if (root.wideMode && !(item.Kirigami.FormData.buddyFor instanceof TextEdit)) {
+                        return Math.max(implicitHeight, item.Kirigami.FormData.buddyFor?.height ?? implicitHeight)
+                    }
+                    return implicitHeight;
+                }
+                return Kirigami.Units.smallSpacing;
+            }
+
+            Layout.alignment: temp.effectiveLayout(item)
+            verticalAlignment: temp.effectiveTextLayout(item)
+
+            Layout.fillWidth: !root.wideMode
+            wrapMode: Text.Wrap
+
+            Layout.topMargin: {
+                if (!item) {
+                    return 0;
+                }
+                if (item.Kirigami.FormData.buddyFor && root.wideMode && item.Kirigami.FormData.buddyFor.parent !== root) {
+                    return item.Kirigami.FormData.buddyFor.y;
+                }
+                if (item?.Kirigami.FormData.isSection && text.length > 0) {
+                    return Kirigami.Units.largeSpacing * 2;
+                }
+                if (index === 0 || root.wideMode) {
+                    return 0;
+                }
+                // EasyRPG Modification: Reduce vertical gap in mobile mode
+                return Kirigami.Units.smallSpacing;
+            }
+            onItemChanged: {
+                if (item.Accessible.hasOwnProperty("labelledBy")) {
+                    item.Accessible.labelledBy = this
+                }
+
+                if (!item) {
+                    destroy();
+                }
+            }
+            Shortcut {
+                sequence: labelItem.Kirigami.MnemonicData.sequence
+                onActivated: {
+                    const buddy = labelItem.item.Kirigami.FormData.buddyFor;
+
+                    const buttonBuddy = buddy as T.AbstractButton;
+                    // animateClick is only in Qt 6.8,
+                    // it also takes into account focus policy.
+                    if (buttonBuddy && buttonBuddy.animateClick) {
+                        buttonBuddy.animateClick();
+                    } else {
+                        buddy.forceActiveFocus(Qt.ShortcutFocusReason);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/common/GridLaneLayout.qml
+++ b/src/ui/common/GridLaneLayout.qml
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: EasyRPG Editor Authors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * A Grid Lane Layout (or Masonry Layout) is similar to a Grid Layout but
+ * with the difference that for each column the gaps are filled.
+ *
+ * Grid Layout:
+ * AB
+ * -B
+ * -B
+ * CD
+ *
+ * Grid Lane Layout (ShortestColumn: Inserts in the column with the lowest Y)
+ * AB
+ * CB
+ * DB
+ *
+ * Grid Lane Layout (Sequential: Insertion order of the elements)
+ * A and C are always in 1st column, B and D in 2nd
+ * AB
+ * CB
+ * -B
+ * -D
+ *
+ * The layout is responsive and will increase/decrease depending on the width
+ * of the window.
+ *
+ */
+Item {
+    id: root
+
+    property int columns: {
+        for (var i = columnMax; i > 0; --i) {
+            if (width > Kirigami.Units.gridUnit * columnWidth * i) {
+                return Math.min(i, repeater.count);
+            }
+        }
+        return 1;
+    }
+
+    /** Max amount of columns to use */
+    property int columnMax: 4
+    /** Size of a column (value is multiplied with gridUnit) */
+    property int columnWidth: 16
+
+    property var model: []
+    property Component delegate: Component {
+        Loader { sourceComponent: modelData }
+    }
+
+    enum PlacementMode {
+        /** Component is placed in column with lowest Y */
+        ShortestColumn = 0,
+        /** Component is placed in order */
+        Sequential = 1
+    }
+
+    property int placementMode: GridLaneLayout.PlacementMode.ShortestColumn
+
+    property int spacing: Kirigami.Units.largeSpacing
+
+    width: parent ? parent.width : 0
+    height: implicitHeight
+
+    implicitHeight: {
+        var mx = 0;
+        if (heights) {
+            for (var i = 0; i < root.columns; i++) {
+                if (heights[i] > mx) mx = heights[i];
+            }
+        }
+        return mx;
+    }
+
+    property var heights: []
+    property int effectiveColumnWidth: Kirigami.Units.gridUnit * columnWidth
+
+    Repeater {
+        id: repeater
+        model: root.model
+        delegate: root.delegate
+
+        onItemAdded: function(index, item) {
+            item.width = Qt.binding(function() {
+                 return root.effectiveColumnWidth;
+            });
+
+            item.heightChanged.connect(root.doRelayout)
+            if (item.hasOwnProperty("implicitHeight")) {
+                item.implicitHeightChanged.connect(root.doRelayout)
+            }
+
+            if (item.hasOwnProperty("item")) {
+                item.itemChanged.connect(function() {
+                    if (item.item) {
+                        item.item.heightChanged.connect(root.doRelayout)
+                        root.doRelayout()
+                    }
+                })
+                if (item.item) {
+                    item.item.heightChanged.connect(root.doRelayout)
+                }
+            }
+
+            root.doRelayout();
+        }
+
+        onItemRemoved: function(index, item) {
+            root.doRelayout()
+        }
+    }
+
+    Connections {
+        target: root
+        function onPlacementModeChanged() { root.doRelayout() }
+        function onColumnsChanged() { root.doRelayout() }
+        function onWidthChanged() { root.doRelayout() }
+    }
+
+    // Grid Lane Distribution based on dynamic heights
+    function doRelayout() {
+        if (!repeater.count) {
+            root.heights = [];
+            return;
+        }
+
+        var colHeights = new Array(root.columns).fill(0);
+
+        var prefW = Kirigami.Units.gridUnit * root.columnWidth;
+        var maxW = prefW + (Kirigami.Units.gridUnit * root.columnWidth) / 2;
+
+        var available = Math.max(0, root.width - (root.columns - 1) * root.spacing);
+        var fitW = Math.floor(available / root.columns);
+        var colW = Math.min(maxW, Math.max(1, fitW));
+
+        root.effectiveColumnWidth = colW;
+        var totalGridWidth = root.columns * colW + (root.columns - 1) * root.spacing;
+        var offsetX = Math.max(0, (root.width - totalGridWidth) / 2);
+
+        for (var i = 0; i < repeater.count; ++i) {
+            var obj = repeater.itemAt(i);
+            if (!obj) continue;
+
+            var targetCol = 0;
+            if (root.placementMode === 1) {
+                targetCol = i % root.columns;
+            } else {
+                // Find shortest column
+                var minH = colHeights[0];
+                for (var j = 1; j < root.columns; ++j) {
+                    if (colHeights[j] < minH) {
+                        targetCol = j;
+                        minH = colHeights[j];
+                    }
+                }
+            }
+
+            // Reposition item
+            obj.x = offsetX + targetCol * (colW + root.spacing);
+            obj.y = colHeights[targetCol];
+
+            // Resolve actual element height
+            var h = obj.height;
+            if (h === 0 && obj.implicitHeight > 0) h = obj.implicitHeight;
+            if (h === 0 && obj.item && obj.item.height > 0) h = obj.item.height;
+
+            colHeights[targetCol] += (h || 100) + root.spacing;
+        }
+
+        root.heights = colHeights;
+    }
+}

--- a/src/ui/database/ActorPage.qml
+++ b/src/ui/database/ActorPage.qml
@@ -12,162 +12,200 @@ import org.easyrpg.editor as Ez
 DatabaseEntryPage {
     id: root
 
-    Models.ListModel {
-        id: equipmentModel
-        Models.ListElement { key: "weapon_id"; label: "Weapon"; type: 1 }
-        Models.ListElement { key: "shield_id"; label: "Shield"; type: 2 }
-        Models.ListElement { key: "armor_id"; label: "Armor"; type: 3 }
-        Models.ListElement { key: "helmet_id"; label: "Helmet"; type: 4 }
-        Models.ListElement { key: "accessory_id"; label: "Accessory"; type: 5 }
+    Ez.GridLaneLayout {
+        id: cardLayout
+
+        model: [
+            card_general,
+            card_graphics,
+            card_equipment
+        ]
     }
 
-    /*property Ez.PickerData charsetPickerData: Ez.PickerData {
-        index: charsetViewer.characterIndex
-        Component.onCompleted: filename = charsetViewer.filename
+    Component {
+        id: card_general
+        Ez.Card {
+            title: qsTr("General")
+
+            Ez.TextField {
+                jsonData: root.jsonData
+                key: "name"
+                Kirigami.FormData.label: "Name"
+                Layout.fillWidth: true
+            }
+
+            Ez.TextField {
+                jsonData: root.jsonData
+                key: "title"
+                Kirigami.FormData.label: "Title"
+                Layout.fillWidth: true
+            }
+
+            RowLayout {
+                Kirigami.FormData.label: "Level"
+
+                Controls.Label {
+                    text: "From"
+                }
+
+                Ez.SpinBox {
+                    jsonData: root.jsonData
+                    key: "initial_level"
+                }
+
+                Controls.Label {
+                    text: "To"
+                }
+
+                Ez.SpinBox {
+                    jsonData: root.jsonData
+                    key: "final_level"
+                }
+            }
+
+            RowLayout {
+                Kirigami.FormData.label: "Crit"
+                Ez.CheckBox {
+                    id: critical_hit_cb
+                    jsonData: root.jsonData
+                    key: "critical_hit"
+                }
+
+                Controls.Label {
+                    text: "One in"
+                    enabled: critical_hit_cb.checked
+                }
+
+                Ez.SpinBox {
+                    jsonData: root.jsonData
+                    key: "critical_hit_chance"
+                    enabled: critical_hit_cb.checked
+                }
+            }
+        }
     }
 
-    property Component charsetPickerComponent: Ez.ImagePicker {
-        onAccepted: {
-            charsetViewer.filename = pickerData.filename
-            charsetViewer.characterIndex = pickerData.index
-            root.jsonData.set("character_name", pickerData.filename)
-            root.jsonData.set("character_index", pickerData.index)
-        }
-    }*/
+    Component {
+        id: card_graphics
+        Ez.Card {
+            title: qsTr("Graphics")
 
-    Ez.FormLayout {
-        id: form1
-        Layout.fillWidth: true
+            Ez.FaceSetViewer {
+                id: faceViewer
+                Kirigami.FormData.label: "Face"
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "General"
-        }
+                filename: root.jsonData.str("face_name")
+                cellIndex: root.jsonData.num("face_index")
 
-        Ez.TextField {
-            jsonData: root.jsonData
-            key: "name"
-            Kirigami.FormData.label: "Name"
-            Layout.fillWidth: true
-        }
+                pickerData: Ez.PickerData {
+                    index: faceViewer.cellIndex
+                    Component.onCompleted: filename = faceViewer.filename
+                }
 
-        Ez.TextField {
-            jsonData: root.jsonData
-            key: "title"
-            Kirigami.FormData.label: "Title"
-            Layout.fillWidth: true
-        }
-
-        RowLayout {
-            Kirigami.FormData.label: "Level"
-
-            Controls.Label {
-                text: "From:"
+                onAccepted: {
+                    faceViewer.filename = pickerData.filename
+                    faceViewer.cellIndex = pickerData.index
+                    root.jsonData.set("face_name", pickerData.filename)
+                    root.jsonData.set("face_index", pickerData.index)
+                }
             }
 
-            Ez.SpinBox {
-                jsonData: root.jsonData
-                key: "initial_level"
-            }
+            Ez.CharSetViewer {
+                id: charViewer
+                Kirigami.FormData.label: "Character"
 
-            Controls.Label {
-                text: "To:"
-            }
+                spin: true
+                walk: true
+                filename: root.jsonData.str("character_name")
+                cellIndex: root.jsonData.num("character_index")
+                transparent: root.jsonData.boolean("transparent")
 
-            Ez.SpinBox {
-                jsonData: root.jsonData
-                key: "final_level"
+                pickerData: Ez.PickerData {
+                    index: charViewer.cellIndex
+                    transparent: charViewer.transparent
+                    Component.onCompleted: filename = charViewer.filename
+                }
+
+                onAccepted: {
+                    charViewer.filename = pickerData.filename
+                    charViewer.cellIndex = pickerData.index
+                    charViewer.transparent = pickerData.transparent
+                    root.jsonData.set("character_name", pickerData.filename)
+                    root.jsonData.set("character_index", pickerData.index)
+                    root.jsonData.set("transparent", pickerData.transparent)
+                }
             }
         }
+    }
 
-        RowLayout {
-            Kirigami.FormData.label: "Crit"
-            Ez.CheckBox {
-                id: critical_hit_cb
-                jsonData: root.jsonData
-                key: "critical_hit"
-            }
-
-            Controls.Label {
-                text: "One in:"
-                enabled: critical_hit_cb.checked
-            }
-
-            Ez.SpinBox {
-                jsonData: root.jsonData
-                key: "critical_hit_chance"
-                enabled: critical_hit_cb.checked
-            }
-        }
-
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Graphics"
-        }
-
-        Ez.FaceSetViewer {
-            id: faceViewer
-            Kirigami.FormData.label: "Face"
-
-            filename: root.jsonData.str("face_name")
-            cellIndex: root.jsonData.num("face_index")
-
-            pickerData: Ez.PickerData {
-                index: faceViewer.cellIndex
-                Component.onCompleted: filename = faceViewer.filename
-            }
-
-            onAccepted: {
-                faceViewer.filename = pickerData.filename
-                faceViewer.cellIndex = pickerData.index
-                root.jsonData.set("face_name", pickerData.filename)
-                root.jsonData.set("face_index", pickerData.index)
-            }
-        }
-
-        Ez.CharSetViewer {
-            id: charViewer
-            Kirigami.FormData.label: "Character"
-
-            spin: true
-            walk: true
-            filename: root.jsonData.str("character_name")
-            cellIndex: root.jsonData.num("character_index")
-            transparent: root.jsonData.boolean("transparent")
-
-            pickerData: Ez.PickerData {
-                index: charViewer.cellIndex
-                transparent: charViewer.transparent
-                Component.onCompleted: filename = charViewer.filename
-            }
-
-            onAccepted: {
-                charViewer.filename = pickerData.filename
-                charViewer.cellIndex = pickerData.index
-                charViewer.transparent = pickerData.transparent
-                root.jsonData.set("character_name", pickerData.filename)
-                root.jsonData.set("character_index", pickerData.index)
-                root.jsonData.set("transparent", pickerData.transparent)
-            }
-        }
-
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Equipment"
-        }
-
-        Repeater {
-            id: equipmentRepeater
-            model: equipmentModel
+    Component {
+        id: card_equipment
+        Ez.Card {
+            title: qsTr("Equipment")
 
             Ez.ComboBox {
-                readonly property var repdata: equipmentRepeater.model.get(index)
                 Layout.fillWidth: true
                 jsonData: root.jsonData
-                key: "initial_equipment/" + repdata.key
-                Kirigami.FormData.label: repdata.label
+                key: "initial_equipment/weapon_id"
+                Kirigami.FormData.label: "Weapon"
                 model: {
-                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(repdata.type);
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(1);
+                    let list = Ez.ProjectData.database().list("items");
+                    list.fallbackString = "(None)";
+                    filter.sourceModel = list;
+                    return filter;
+                }
+            }
+
+            Ez.ComboBox {
+                Layout.fillWidth: true
+                jsonData: root.jsonData
+                key: "initial_equipment/shield_id"
+                Kirigami.FormData.label: "Shield"
+                model: {
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(2);
+                    let list = Ez.ProjectData.database().list("items");
+                    list.fallbackString = "(None)";
+                    filter.sourceModel = list;
+                    return filter;
+                }
+            }
+
+            Ez.ComboBox {
+                Layout.fillWidth: true
+                jsonData: root.jsonData
+                key: "initial_equipment/armor_id"
+                Kirigami.FormData.label: "Armor"
+                model: {
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(3);
+                    let list = Ez.ProjectData.database().list("items");
+                    list.fallbackString = "(None)";
+                    filter.sourceModel = list;
+                    return filter;
+                }
+            }
+
+            Ez.ComboBox {
+                Layout.fillWidth: true
+                jsonData: root.jsonData
+                key: "initial_equipment/helmet_id"
+                Kirigami.FormData.label: "Helmet"
+                model: {
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(4);
+                    let list = Ez.ProjectData.database().list("items");
+                    list.fallbackString = "(None)";
+                    filter.sourceModel = list;
+                    return filter;
+                }
+            }
+
+            Ez.ComboBox {
+                Layout.fillWidth: true
+                jsonData: root.jsonData
+                key: "initial_equipment/accessory_id"
+                Kirigami.FormData.label: "Accessory"
+                model: {
+                    let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(5);
                     let list = Ez.ProjectData.database().list("items");
                     list.fallbackString = "(None)";
                     filter.sourceModel = list;

--- a/src/ui/database/ActorPage.qml
+++ b/src/ui/database/ActorPage.qml
@@ -30,22 +30,22 @@ DatabaseEntryPage {
             Ez.TextField {
                 jsonData: root.jsonData
                 key: "name"
-                Kirigami.FormData.label: "Name"
+                Kirigami.FormData.label: qsTr("Name")
                 Layout.fillWidth: true
             }
 
             Ez.TextField {
                 jsonData: root.jsonData
                 key: "title"
-                Kirigami.FormData.label: "Title"
+                Kirigami.FormData.label: qsTr("Title")
                 Layout.fillWidth: true
             }
 
             RowLayout {
-                Kirigami.FormData.label: "Level"
+                Kirigami.FormData.label: qsTr("Level")
 
                 Controls.Label {
-                    text: "From"
+                    text: qsTr("From")
                 }
 
                 Ez.SpinBox {
@@ -54,7 +54,7 @@ DatabaseEntryPage {
                 }
 
                 Controls.Label {
-                    text: "To"
+                    text: qsTr("To")
                 }
 
                 Ez.SpinBox {
@@ -64,7 +64,7 @@ DatabaseEntryPage {
             }
 
             RowLayout {
-                Kirigami.FormData.label: "Crit"
+                Kirigami.FormData.label: qsTr("Critical Hit Rate")
                 Ez.CheckBox {
                     id: critical_hit_cb
                     jsonData: root.jsonData
@@ -72,7 +72,7 @@ DatabaseEntryPage {
                 }
 
                 Controls.Label {
-                    text: "One in"
+                    text: qsTr("One in")
                     enabled: critical_hit_cb.checked
                 }
 
@@ -92,7 +92,7 @@ DatabaseEntryPage {
 
             Ez.FaceSetViewer {
                 id: faceViewer
-                Kirigami.FormData.label: "Face"
+                Kirigami.FormData.label: qsTr("Face")
 
                 filename: root.jsonData.str("face_name")
                 cellIndex: root.jsonData.num("face_index")
@@ -112,7 +112,7 @@ DatabaseEntryPage {
 
             Ez.CharSetViewer {
                 id: charViewer
-                Kirigami.FormData.label: "Character"
+                Kirigami.FormData.label: qsTr("Character")
 
                 spin: true
                 walk: true
@@ -147,11 +147,11 @@ DatabaseEntryPage {
                 Layout.fillWidth: true
                 jsonData: root.jsonData
                 key: "initial_equipment/weapon_id"
-                Kirigami.FormData.label: "Weapon"
+                Kirigami.FormData.label: qsTr("Weapon")
                 model: {
                     let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(1);
                     let list = Ez.ProjectData.database().list("items");
-                    list.fallbackString = "(None)";
+                    list.fallbackString = qsTr("(None)");
                     filter.sourceModel = list;
                     return filter;
                 }
@@ -161,11 +161,11 @@ DatabaseEntryPage {
                 Layout.fillWidth: true
                 jsonData: root.jsonData
                 key: "initial_equipment/shield_id"
-                Kirigami.FormData.label: "Shield"
+                Kirigami.FormData.label: qsTr("Shield")
                 model: {
                     let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(2);
                     let list = Ez.ProjectData.database().list("items");
-                    list.fallbackString = "(None)";
+                    list.fallbackString = qsTr("(None)");
                     filter.sourceModel = list;
                     return filter;
                 }
@@ -175,11 +175,11 @@ DatabaseEntryPage {
                 Layout.fillWidth: true
                 jsonData: root.jsonData
                 key: "initial_equipment/armor_id"
-                Kirigami.FormData.label: "Armor"
+                Kirigami.FormData.label: qsTr("Armor")
                 model: {
                     let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(3);
                     let list = Ez.ProjectData.database().list("items");
-                    list.fallbackString = "(None)";
+                    list.fallbackString = qsTr("(None)");
                     filter.sourceModel = list;
                     return filter;
                 }
@@ -189,11 +189,11 @@ DatabaseEntryPage {
                 Layout.fillWidth: true
                 jsonData: root.jsonData
                 key: "initial_equipment/helmet_id"
-                Kirigami.FormData.label: "Helmet"
+                Kirigami.FormData.label: qsTr("Helmet")
                 model: {
                     let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(4);
                     let list = Ez.ProjectData.database().list("items");
-                    list.fallbackString = "(None)";
+                    list.fallbackString = qsTr("(None)");
                     filter.sourceModel = list;
                     return filter;
                 }
@@ -203,11 +203,11 @@ DatabaseEntryPage {
                 Layout.fillWidth: true
                 jsonData: root.jsonData
                 key: "initial_equipment/accessory_id"
-                Kirigami.FormData.label: "Accessory"
+                Kirigami.FormData.label: qsTr("Accessory")
                 model: {
                     let filter = Ez.ProjectData.actorModel(root.objIndex).CreateEquipmentFilter(5);
                     let list = Ez.ProjectData.database().list("items");
-                    list.fallbackString = "(None)";
+                    list.fallbackString = qsTr("(None)");
                     filter.sourceModel = list;
                     return filter;
                 }

--- a/src/ui/database/ActorPage.qml
+++ b/src/ui/database/ActorPage.qml
@@ -14,11 +14,11 @@ DatabaseEntryPage {
 
     Models.ListModel {
         id: equipmentModel
-        Models.ListElement { key: "weapon_id"; label: "Weapon:"; type: 1 }
-        Models.ListElement { key: "shield_id"; label: "Shield:"; type: 2 }
-        Models.ListElement { key: "armor_id"; label: "Armor:"; type: 3 }
-        Models.ListElement { key: "helmet_id"; label: "Helmet:"; type: 4 }
-        Models.ListElement { key: "accessory_id"; label: "Accessory:"; type: 5 }
+        Models.ListElement { key: "weapon_id"; label: "Weapon"; type: 1 }
+        Models.ListElement { key: "shield_id"; label: "Shield"; type: 2 }
+        Models.ListElement { key: "armor_id"; label: "Armor"; type: 3 }
+        Models.ListElement { key: "helmet_id"; label: "Helmet"; type: 4 }
+        Models.ListElement { key: "accessory_id"; label: "Accessory"; type: 5 }
     }
 
     /*property Ez.PickerData charsetPickerData: Ez.PickerData {
@@ -35,7 +35,7 @@ DatabaseEntryPage {
         }
     }*/
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         id: form1
         Layout.fillWidth: true
 
@@ -47,19 +47,19 @@ DatabaseEntryPage {
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name:"
+            Kirigami.FormData.label: "Name"
             Layout.fillWidth: true
         }
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "title"
-            Kirigami.FormData.label: "Title:"
+            Kirigami.FormData.label: "Title"
             Layout.fillWidth: true
         }
 
         RowLayout {
-            Kirigami.FormData.label: "Level:"
+            Kirigami.FormData.label: "Level"
 
             Controls.Label {
                 text: "From:"
@@ -81,7 +81,7 @@ DatabaseEntryPage {
         }
 
         RowLayout {
-            Kirigami.FormData.label: "Crit:"
+            Kirigami.FormData.label: "Crit"
             Ez.CheckBox {
                 id: critical_hit_cb
                 jsonData: root.jsonData
@@ -107,7 +107,7 @@ DatabaseEntryPage {
 
         Ez.FaceSetViewer {
             id: faceViewer
-            Kirigami.FormData.label: "Face:"
+            Kirigami.FormData.label: "Face"
 
             filename: root.jsonData.str("face_name")
             cellIndex: root.jsonData.num("face_index")
@@ -127,7 +127,7 @@ DatabaseEntryPage {
 
         Ez.CharSetViewer {
             id: charViewer
-            Kirigami.FormData.label: "Character:"
+            Kirigami.FormData.label: "Character"
 
             spin: true
             walk: true

--- a/src/ui/database/AttributePage.qml
+++ b/src/ui/database/AttributePage.qml
@@ -14,24 +14,24 @@ DatabaseEntryPage {
 
     Models.ListModel {
         id: rateModel
-        Models.ListElement { key: "a_rate"; label: "A Rate:" }
-        Models.ListElement { key: "b_rate"; label: "B Rate:" }
-        Models.ListElement { key: "c_rate"; label: "C Rate:" }
-        Models.ListElement { key: "d_rate"; label: "D Rate:" }
-        Models.ListElement { key: "e_rate"; label: "E Rate:" }
+        Models.ListElement { key: "a_rate"; label: "A Rate" }
+        Models.ListElement { key: "b_rate"; label: "B Rate" }
+        Models.ListElement { key: "c_rate"; label: "C Rate" }
+        Models.ListElement { key: "d_rate"; label: "D Rate" }
+        Models.ListElement { key: "e_rate"; label: "E Rate" }
     }
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         anchors.fill: parent
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name:"
+            Kirigami.FormData.label: "Name"
         }
 
         ColumnLayout {
-            Kirigami.FormData.label: "Attribute Type:"
+            Kirigami.FormData.label: "Attribute Type"
             Kirigami.FormData.buddyFor: radio_physical
             Ez.RadioButton {
                 id: radio_physical

--- a/src/ui/database/AttributePage.qml
+++ b/src/ui/database/AttributePage.qml
@@ -12,57 +12,95 @@ import org.easyrpg.editor as Ez
 DatabaseEntryPage {
     id: root
 
-    Models.ListModel {
-        id: rateModel
-        Models.ListElement { key: "a_rate"; label: "A Rate" }
-        Models.ListElement { key: "b_rate"; label: "B Rate" }
-        Models.ListElement { key: "c_rate"; label: "C Rate" }
-        Models.ListElement { key: "d_rate"; label: "D Rate" }
-        Models.ListElement { key: "e_rate"; label: "E Rate" }
+    Ez.GridLaneLayout {
+        id: cardLayout
+        model: [card_general, card_dmg]
     }
 
-    Ez.FormLayout {
-        anchors.fill: parent
+    Component {
+        id: card_general
+        Ez.Card {
+            title: qsTr("General")
 
-        Ez.TextField {
-            jsonData: root.jsonData
-            key: "name"
-            Kirigami.FormData.label: "Name"
-        }
-
-        ColumnLayout {
-            Kirigami.FormData.label: "Attribute Type"
-            Kirigami.FormData.buddyFor: radio_physical
-            Ez.RadioButton {
-                id: radio_physical
+            Ez.TextField {
                 jsonData: root.jsonData
-                key: "type"
-                text: "Physical"
-                value: 0
+                key: "name"
+                Kirigami.FormData.label: "Name"
             }
-            Ez.RadioButton {
-                jsonData: root.jsonData
-                key: "type"
-                text: "Magical"
-                value: 1
+
+            ColumnLayout {
+                Kirigami.FormData.label: "Attribute Type"
+                Kirigami.FormData.buddyFor: radio_physical
+                Ez.RadioButton {
+                    id: radio_physical
+                    jsonData: root.jsonData
+                    key: "type"
+                    text: "Physical"
+                    value: 0
+                }
+                Ez.RadioButton {
+                    jsonData: root.jsonData
+                    key: "type"
+                    text: "Magical"
+                    value: 1
+                }
             }
         }
+    }
 
-        Kirigami.Separator {
-            Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Damage Multipliers"
-        }
-
-        Repeater {
-            model: rateModel
+    Component {
+        id: card_dmg
+        Ez.Card {
+            title: qsTr("Damage Multipliers")
 
             Ez.SpinBox {
                 jsonData: root.jsonData
-                key: model.key
-                Kirigami.FormData.label: model.label
+                key: "a_rate"
+                Kirigami.FormData.label: "A Rate"
                 from: -9999
                 to: 9999
                 suffix: "%"
+                Layout.fillWidth: true
+            }
+
+            Ez.SpinBox {
+                jsonData: root.jsonData
+                key: "b_rate"
+                Kirigami.FormData.label: "B Rate"
+                from: -9999
+                to: 9999
+                suffix: "%"
+                Layout.fillWidth: true
+            }
+
+            Ez.SpinBox {
+                jsonData: root.jsonData
+                key: "c_rate"
+                Kirigami.FormData.label: "C Rate"
+                from: -9999
+                to: 9999
+                suffix: "%"
+                Layout.fillWidth: true
+            }
+
+            Ez.SpinBox {
+                jsonData: root.jsonData
+                key: "d_rate"
+                Kirigami.FormData.label: "D Rate"
+                from: -9999
+                to: 9999
+                suffix: "%"
+                Layout.fillWidth: true
+            }
+
+            Ez.SpinBox {
+                jsonData: root.jsonData
+                key: "e_rate"
+                Kirigami.FormData.label: "E Rate"
+                from: -9999
+                to: 9999
+                suffix: "%"
+                Layout.fillWidth: true
             }
         }
     }

--- a/src/ui/database/AttributePage.qml
+++ b/src/ui/database/AttributePage.qml
@@ -25,23 +25,23 @@ DatabaseEntryPage {
             Ez.TextField {
                 jsonData: root.jsonData
                 key: "name"
-                Kirigami.FormData.label: "Name"
+                Kirigami.FormData.label: qsTr("Name")
             }
 
             ColumnLayout {
-                Kirigami.FormData.label: "Attribute Type"
+                Kirigami.FormData.label: qsTr("Attribute Type")
                 Kirigami.FormData.buddyFor: radio_physical
                 Ez.RadioButton {
                     id: radio_physical
                     jsonData: root.jsonData
                     key: "type"
-                    text: "Physical"
+                    text: qsTr("Physical")
                     value: 0
                 }
                 Ez.RadioButton {
                     jsonData: root.jsonData
                     key: "type"
-                    text: "Magical"
+                    text: qsTr("Magical")
                     value: 1
                 }
             }
@@ -56,50 +56,50 @@ DatabaseEntryPage {
             Ez.SpinBox {
                 jsonData: root.jsonData
                 key: "a_rate"
-                Kirigami.FormData.label: "A Rate"
+                Kirigami.FormData.label: qsTr("A Rate")
                 from: -9999
                 to: 9999
-                suffix: "%"
+                suffix: qsTr("%")
                 Layout.fillWidth: true
             }
 
             Ez.SpinBox {
                 jsonData: root.jsonData
                 key: "b_rate"
-                Kirigami.FormData.label: "B Rate"
+                Kirigami.FormData.label: qsTr("B Rate")
                 from: -9999
                 to: 9999
-                suffix: "%"
+                suffix: qsTr("%")
                 Layout.fillWidth: true
             }
 
             Ez.SpinBox {
                 jsonData: root.jsonData
                 key: "c_rate"
-                Kirigami.FormData.label: "C Rate"
+                Kirigami.FormData.label: qsTr("C Rate")
                 from: -9999
                 to: 9999
-                suffix: "%"
+                suffix: qsTr("%")
                 Layout.fillWidth: true
             }
 
             Ez.SpinBox {
                 jsonData: root.jsonData
                 key: "d_rate"
-                Kirigami.FormData.label: "D Rate"
+                Kirigami.FormData.label: qsTr("D Rate")
                 from: -9999
                 to: 9999
-                suffix: "%"
+                suffix: qsTr("%")
                 Layout.fillWidth: true
             }
 
             Ez.SpinBox {
                 jsonData: root.jsonData
                 key: "e_rate"
-                Kirigami.FormData.label: "E Rate"
+                Kirigami.FormData.label: qsTr("E Rate")
                 from: -9999
                 to: 9999
-                suffix: "%"
+                suffix: qsTr("%")
                 Layout.fillWidth: true
             }
         }

--- a/src/ui/database/DatabaseEntryPage.qml
+++ b/src/ui/database/DatabaseEntryPage.qml
@@ -45,7 +45,7 @@ Kirigami.ScrollablePage {
 
     actions: [
         Kirigami.Action {
-            text: "Cancel"
+            text: qsTr("Cancel")
             icon.name: "cancel"
             onTriggered: {
                 applicationWindow().pageStack.pop()
@@ -54,7 +54,7 @@ Kirigami.ScrollablePage {
             visible: showActions
         },
         Kirigami.Action {
-            text: "Select"
+            text: qsTr("Select")
             icon.name: "confirm"
             onTriggered: {
                 applicationWindow().pageStack.pop()

--- a/src/ui/database/DatabasePage.qml
+++ b/src/ui/database/DatabasePage.qml
@@ -18,7 +18,7 @@ Kirigami.ScrollablePage {
     /** Database of the current project */
     property Ez.JsonView jsonData
 
-    title: "Database"
+    title: qsTr("Database")
 
     /**
      * name: Text shown to the user
@@ -29,33 +29,33 @@ Kirigami.ScrollablePage {
     ListModel {
         id: pageModel
         ListElement {
-            name: "Actors"
+            name: qsTr("Actors")
             key: "actors"
             targetPage: "ActorPage.qml"
         }
         ListElement {
-            name: "Items"
+            name: qsTr("Items")
             key: "items"
             targetPage: "ItemPage.qml"
         }
         ListElement {
-            name: "Skills"
+            name: qsTr("Skills")
             key: "skills"
             targetPage: "SkillPage.qml"
         }
         ListElement {
-            name: "Attributes"
+            name: qsTr("Attributes")
             key: "attributes"
             targetPage: "AttributePage.qml"
         }
         ListElement {
-            name: "System"
+            name: qsTr("System")
             key: "system"
             targetPage: "SystemPage.qml"
             single: true
         }
         ListElement {
-            name: "Vocabulary"
+            name: qsTr("Vocabulary")
             key: "terms"
             targetPage: "VocabularyPage.qml"
             single: true

--- a/src/ui/database/DatabaseWindow.qml
+++ b/src/ui/database/DatabaseWindow.qml
@@ -19,7 +19,7 @@ Kirigami.ApplicationWindow {
     width: Kirigami.Units.gridUnit * 74
     height: Kirigami.Units.gridUnit * 41
 
-    title: "EasyRPG Editor - Database"
+    title: qsTr("EasyRPG Editor - Database")
 
     pageStack.defaultColumnWidth: Kirigami.Units.gridUnit * 11
 

--- a/src/ui/database/ItemPage.qml
+++ b/src/ui/database/ItemPage.qml
@@ -18,13 +18,13 @@ DatabaseEntryPage {
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name"
+            Kirigami.FormData.label: qsTr("Name")
         }
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "description"
-            Kirigami.FormData.label: "Description"
+            Kirigami.FormData.label: qsTr("Description")
         }
     }
 }

--- a/src/ui/database/ItemPage.qml
+++ b/src/ui/database/ItemPage.qml
@@ -12,19 +12,19 @@ DatabaseEntryPage {
 
     property Ez.JsonView jsonData
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         anchors.fill: parent
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name:"
+            Kirigami.FormData.label: "Name"
         }
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "description"
-            Kirigami.FormData.label: "Description:"
+            Kirigami.FormData.label: "Description"
         }
     }
 }

--- a/src/ui/database/SkillPage.qml
+++ b/src/ui/database/SkillPage.qml
@@ -13,10 +13,10 @@ DatabaseEntryPage {
 
     Models.ListModel {
         id: typeModel
-        Models.ListElement { value: 0; text: "Normal" }
-        Models.ListElement { value: 1; text: "Teleport" }
-        Models.ListElement { value: 2; text: "Escape" }
-        Models.ListElement { value: 3; text: "Switch" }
+        Models.ListElement { value: 0; text: qsTr("Normal") }
+        Models.ListElement { value: 1; text: qsTr("Teleport") }
+        Models.ListElement { value: 2; text: qsTr("Escape") }
+        Models.ListElement { value: 3; text: qsTr("Switch") }
     }
 
     Ez.FormLayout {
@@ -25,20 +25,20 @@ DatabaseEntryPage {
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name"
+            Kirigami.FormData.label: qsTr("Name")
         }
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "description"
-            Kirigami.FormData.label: "Description"
+            Kirigami.FormData.label: qsTr("Description")
         }
 
         Ez.ComboBox {
             id: cbType
             jsonData: root.jsonData
             key: "type"
-            Kirigami.FormData.label: "Type"
+            Kirigami.FormData.label: qsTr("Type")
             model: typeModel
         }
     }

--- a/src/ui/database/SkillPage.qml
+++ b/src/ui/database/SkillPage.qml
@@ -19,26 +19,26 @@ DatabaseEntryPage {
         Models.ListElement { value: 3; text: "Switch" }
     }
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         anchors.fill: parent
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "name"
-            Kirigami.FormData.label: "Name:"
+            Kirigami.FormData.label: "Name"
         }
 
         Ez.TextField {
             jsonData: root.jsonData
             key: "description"
-            Kirigami.FormData.label: "Description:"
+            Kirigami.FormData.label: "Description"
         }
 
         Ez.ComboBox {
             id: cbType
             jsonData: root.jsonData
             key: "type"
-            Kirigami.FormData.label: "Type: "
+            Kirigami.FormData.label: "Type"
             model: typeModel
         }
     }

--- a/src/ui/database/SystemPage.qml
+++ b/src/ui/database/SystemPage.qml
@@ -76,7 +76,7 @@ DatabaseEntryPage {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Title"
+            Kirigami.FormData.label: qsTr("Title")
         }
 
         JsonImageViewer {
@@ -86,7 +86,7 @@ DatabaseEntryPage {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Game Over"
+            Kirigami.FormData.label: qsTr("Game Over")
         }
 
         JsonImageViewer {
@@ -96,7 +96,7 @@ DatabaseEntryPage {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "System"
+            Kirigami.FormData.label: qsTr("System")
         }
 
         JsonImageViewer {
@@ -106,7 +106,7 @@ DatabaseEntryPage {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "System 2"
+            Kirigami.FormData.label: qsTr("System 2")
         }
 
         JsonImageViewer {
@@ -116,136 +116,135 @@ DatabaseEntryPage {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Music"
+            Kirigami.FormData.label: qsTr("Music")
         }
 
         JsonMusicViewer {
             key: "title_music"
-            Kirigami.FormData.label: "Title"
+            Kirigami.FormData.label: qsTr("Title")
         }
 
         JsonMusicViewer {
             key: "gameover_music"
-            Kirigami.FormData.label: "Game Over"
+            Kirigami.FormData.label: qsTr("Game Over")
         }
 
         JsonMusicViewer {
             key: "inn_music"
-            Kirigami.FormData.label: "Inn"
+            Kirigami.FormData.label: qsTr("Inn")
         }
 
         JsonMusicViewer {
             key: "boat_music"
-            Kirigami.FormData.label: "Boat"
+            Kirigami.FormData.label: qsTr("Boat")
         }
 
         JsonMusicViewer {
             key: "ship_music"
-            Kirigami.FormData.label: "Ship"
+            Kirigami.FormData.label: qsTr("Ship")
         }
 
         JsonMusicViewer {
             key: "airship_music"
-            Kirigami.FormData.label: "Airship"
+            Kirigami.FormData.label: qsTr("Airship")
         }
 
         JsonMusicViewer {
             key: "battle_music"
-            Kirigami.FormData.label: "Battle"
+            Kirigami.FormData.label: qsTr("Battle")
         }
 
         JsonMusicViewer {
             key: "battle_end_music"
-            Kirigami.FormData.label: "Battle End"
+            Kirigami.FormData.label: qsTr("Battle End")
         }
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Sound"
+            Kirigami.FormData.label: qsTr("Sound")
         }
-
 
         JsonSoundViewer {
             key: "cursor_se"
-            Kirigami.FormData.label: "Cursor"
+            Kirigami.FormData.label: qsTr("Cursor")
         }
 
         JsonSoundViewer {
             key: "decision_se"
-            Kirigami.FormData.label: "Decision"
+            Kirigami.FormData.label: qsTr("Decision")
         }
 
         JsonSoundViewer {
             key: "cancel_se"
-            Kirigami.FormData.label: "Cancel"
+            Kirigami.FormData.label: qsTr("Cancel")
         }
 
         JsonSoundViewer {
             key: "buzzer_se"
-            Kirigami.FormData.label: "Buzzer"
+            Kirigami.FormData.label: qsTr("Buzzer")
         }
 
         JsonSoundViewer {
             key: "battle_se"
-            Kirigami.FormData.label: "Battle"
+            Kirigami.FormData.label: qsTr("Battle")
         }
 
         JsonSoundViewer {
             key: "escape_se"
-            Kirigami.FormData.label: "Escape"
+            Kirigami.FormData.label: qsTr("Escape")
         }
 
         JsonSoundViewer {
             key: "enemy_attack_se"
-            Kirigami.FormData.label: "Enemy Attack"
+            Kirigami.FormData.label: qsTr("Enemy Attack")
         }
 
         JsonSoundViewer {
             key: "enemy_damaged_se"
-            Kirigami.FormData.label: "Enemy Damaged"
+            Kirigami.FormData.label: qsTr("Enemy Damaged")
         }
 
         JsonSoundViewer {
             key: "actor_damaged_se"
-            Kirigami.FormData.label: "Actor Damaged"
+            Kirigami.FormData.label: qsTr("Actor Damaged")
         }
 
         JsonSoundViewer {
             key: "dodge_se"
-            Kirigami.FormData.label: "Dodge"
+            Kirigami.FormData.label: qsTr("Dodge")
         }
 
         JsonSoundViewer {
             key: "enemy_death_se"
-            Kirigami.FormData.label: "Enemy Death"
+            Kirigami.FormData.label: qsTr("Enemy Death")
         }
 
         JsonSoundViewer {
             key: "item_se"
-            Kirigami.FormData.label: "Item"
+            Kirigami.FormData.label: qsTr("Item")
         }
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: "Vehicles"
+            Kirigami.FormData.label: qsTr("Vehicles")
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Boat"
+            Kirigami.FormData.label: qsTr("Boat")
             nameKey: "boat_name"
             indexKey: "boat_index"
             showTransparency: false
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Ship"
+            Kirigami.FormData.label: qsTr("Ship")
             nameKey: "ship_name"
             indexKey: "ship_index"
             showTransparency: false
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Airship"
+            Kirigami.FormData.label: qsTr("Airship")
             nameKey: "airship_name"
             indexKey: "airship_index"
             showTransparency: false

--- a/src/ui/database/SystemPage.qml
+++ b/src/ui/database/SystemPage.qml
@@ -71,7 +71,7 @@ DatabaseEntryPage {
         }
     }
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         anchors.fill: parent
 
         Kirigami.Separator {
@@ -121,42 +121,42 @@ DatabaseEntryPage {
 
         JsonMusicViewer {
             key: "title_music"
-            Kirigami.FormData.label: "Title:"
+            Kirigami.FormData.label: "Title"
         }
 
         JsonMusicViewer {
             key: "gameover_music"
-            Kirigami.FormData.label: "Game Over:"
+            Kirigami.FormData.label: "Game Over"
         }
 
         JsonMusicViewer {
             key: "inn_music"
-            Kirigami.FormData.label: "Inn:"
+            Kirigami.FormData.label: "Inn"
         }
 
         JsonMusicViewer {
             key: "boat_music"
-            Kirigami.FormData.label: "Boat:"
+            Kirigami.FormData.label: "Boat"
         }
 
         JsonMusicViewer {
             key: "ship_music"
-            Kirigami.FormData.label: "Ship:"
+            Kirigami.FormData.label: "Ship"
         }
 
         JsonMusicViewer {
             key: "airship_music"
-            Kirigami.FormData.label: "Airship:"
+            Kirigami.FormData.label: "Airship"
         }
 
         JsonMusicViewer {
             key: "battle_music"
-            Kirigami.FormData.label: "Battle:"
+            Kirigami.FormData.label: "Battle"
         }
 
         JsonMusicViewer {
             key: "battle_end_music"
-            Kirigami.FormData.label: "Battle End:"
+            Kirigami.FormData.label: "Battle End"
         }
 
         Kirigami.Separator {
@@ -167,62 +167,62 @@ DatabaseEntryPage {
 
         JsonSoundViewer {
             key: "cursor_se"
-            Kirigami.FormData.label: "Cursor:"
+            Kirigami.FormData.label: "Cursor"
         }
 
         JsonSoundViewer {
             key: "decision_se"
-            Kirigami.FormData.label: "Decision:"
+            Kirigami.FormData.label: "Decision"
         }
 
         JsonSoundViewer {
             key: "cancel_se"
-            Kirigami.FormData.label: "Cancel:"
+            Kirigami.FormData.label: "Cancel"
         }
 
         JsonSoundViewer {
             key: "buzzer_se"
-            Kirigami.FormData.label: "Buzzer:"
+            Kirigami.FormData.label: "Buzzer"
         }
 
         JsonSoundViewer {
             key: "battle_se"
-            Kirigami.FormData.label: "Battle:"
+            Kirigami.FormData.label: "Battle"
         }
 
         JsonSoundViewer {
             key: "escape_se"
-            Kirigami.FormData.label: "Escape:"
+            Kirigami.FormData.label: "Escape"
         }
 
         JsonSoundViewer {
             key: "enemy_attack_se"
-            Kirigami.FormData.label: "Enemy Attack:"
+            Kirigami.FormData.label: "Enemy Attack"
         }
 
         JsonSoundViewer {
             key: "enemy_damaged_se"
-            Kirigami.FormData.label: "Enemy Damaged:"
+            Kirigami.FormData.label: "Enemy Damaged"
         }
 
         JsonSoundViewer {
             key: "actor_damaged_se"
-            Kirigami.FormData.label: "Actor Damaged:"
+            Kirigami.FormData.label: "Actor Damaged"
         }
 
         JsonSoundViewer {
             key: "dodge_se"
-            Kirigami.FormData.label: "Dodge:"
+            Kirigami.FormData.label: "Dodge"
         }
 
         JsonSoundViewer {
             key: "enemy_death_se"
-            Kirigami.FormData.label: "Enemy Death:"
+            Kirigami.FormData.label: "Enemy Death"
         }
 
         JsonSoundViewer {
             key: "item_se"
-            Kirigami.FormData.label: "Item:"
+            Kirigami.FormData.label: "Item"
         }
 
         Kirigami.Separator {
@@ -231,21 +231,21 @@ DatabaseEntryPage {
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Boat:"
+            Kirigami.FormData.label: "Boat"
             nameKey: "boat_name"
             indexKey: "boat_index"
             showTransparency: false
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Ship:"
+            Kirigami.FormData.label: "Ship"
             nameKey: "ship_name"
             indexKey: "ship_index"
             showTransparency: false
         }
 
         JsonCharSetViewer {
-            Kirigami.FormData.label: "Airship:"
+            Kirigami.FormData.label: "Airship"
             nameKey: "airship_name"
             indexKey: "airship_index"
             showTransparency: false

--- a/src/ui/database/VocabularyPage.qml
+++ b/src/ui/database/VocabularyPage.qml
@@ -15,7 +15,7 @@ DatabaseEntryPage {
     // Just for demonstration
     // The finished Ui should not be auto-generated :)
 
-    Kirigami.FormLayout {
+    Ez.FormLayout {
         anchors.fill: parent
 
         Repeater {

--- a/src/ui/database/VocabularyPage.qml
+++ b/src/ui/database/VocabularyPage.qml
@@ -10,31 +10,276 @@ import org.easyrpg.editor as Ez
 DatabaseEntryPage {
     id: root
 
-    property var jsonKeys:[]
+    readonly property var categoryModel: [
+    {
+        label: qsTr("Title"),
+        section: 0,
+        settings: [
+            { label: qsTr("New Game"), key: "new_game" },
+            { label: qsTr("Continue"), key: "load_game" },
+            { label: qsTr("Exit"), key: "exit_game" }
+        ]
+    },
+    {
+        label: qsTr("Menu"),
+        section: 0,
+        settings: [
+            { label: qsTr("Items (Shared with Battle)"), key: "command_item" },
+            { label: qsTr("Skills (Shared with Battle)"), key: "command_skill" },
+            { label: qsTr("Equipment"), key: "menu_equipment" },
+            { label: qsTr("Status"), key: "status" },
+            { label: qsTr("Order"), key: "order" },
+            { label: qsTr("Save"), key: "menu_save" },
+            { label: qsTr("Quit"), key: "menu_quit" },
+            { label: qsTr("Change Row (Shared with Battle)"), key: "row" },
+            { label: qsTr("Enable Wait"), key: "wait_on" },
+            { label: qsTr("Disable Wait"), key: "wait_off" }
+        ]
+    },
+    {
+        label: qsTr("Attributes"),
+        section: 0,
+        settings: [
+            { label: qsTr("HP"), key: "health_points" },
+            { label: qsTr("HP (Short Form)"), key: "hp_short" },
+            { label: qsTr("MP"), key: "spirit_points" },
+            { label: qsTr("MP (Short Form)"), key: "sp_short" },
+            { label: qsTr("Level"), key: "level" },
+            { label: qsTr("Level (Short Form)"), key: "lvl_short" },
+            { label: qsTr("Experience"), key: "exp_short" },
+            { label: qsTr("Attack"), key: "attack" },
+            { label: qsTr("Defense"), key: "defense" },
+            { label: qsTr("Mind"), key: "spirit" },
+            { label: qsTr("Agility"), key: "agility" }
+        ]
+    },
+    {
+        label: qsTr("Equipment"),
+        section: 0,
+        settings: [
+            { label: qsTr("Weapon"), key: "weapon" },
+            { label: qsTr("Shield"), key: "shield" },
+            { label: qsTr("Armor"), key: "armor" },
+            { label: qsTr("Helmet"), key: "helmet" },
+            { label: qsTr("Accessory"), key: "accessory" }
+        ]
+    },
+    {
+        label: qsTr("Save/Load/Exit"),
+        section: 0,
+        settings: [
+            { label: qsTr("Yes"), key: "yes" },
+            { label: qsTr("No"), key: "no" },
+            { label: qsTr("Save Name"), key: "file" },
+            { label: qsTr("Save Select"), key: "save_game_message" },
+            { label: qsTr("Load Select"), key: "load_game_message" },
+            { label: qsTr("Exit Message"), key: "exit_game_message" }
+        ]
+    },
+    {
+        label: qsTr("Other"),
+        section: 0,
+        settings: [
+            { label: qsTr("Normal Status"), key: "normal_status" },
+            { label: qsTr("Currency"), key: "gold" },
+            { label: qsTr("MP Cost"), key: "sp_cost" },
+            { label: qsTr("Level Up"), key: "level_up" },
+            { label: qsTr("New Skill"), key: "skill_learned" }
+        ]
+    },
+    {
+        label: qsTr("Shop Type A"),
+        section: 1,
+        settings: [
+            { label: qsTr("Greeting"), key: "shop_greeting1" },
+            { label: qsTr("Regreeting"), key: "shop_regreeting1" },
+            { label: qsTr("Buy"), key: "shop_buy1" },
+            { label: qsTr("Sell"), key: "shop_sell1" },
+            { label: qsTr("Leave"), key: "shop_leave1" },
+            { label: qsTr("Purchasing"), key: "shop_buy_select1" },
+            { label: qsTr("Amount"), key: "shop_buy_number1" },
+            { label: qsTr("Purchase Done"), key: "shop_purchased1" },
+            { label: qsTr("Selling"), key: "shop_sell_select1" },
+            { label: qsTr("Amount"), key: "shop_sell_number1" },
+            { label: qsTr("Sold"), key: "shop_sold1" }
+        ]
+    },
+    {
+        label: qsTr("Shop Type B"),
+        section: 1,
+        settings: [
+            { label: qsTr("Greeting"), key: "shop_greeting2" },
+            { label: qsTr("Regreeting"), key: "shop_regreeting2" },
+            { label: qsTr("Buy"), key: "shop_buy2" },
+            { label: qsTr("Sell"), key: "shop_sell2" },
+            { label: qsTr("Leave"), key: "shop_leave2" },
+            { label: qsTr("Purchasing"), key: "shop_buy_select2" },
+            { label: qsTr("Amount"), key: "shop_buy_number2" },
+            { label: qsTr("Purchase Done"), key: "shop_purchased2" },
+            { label: qsTr("Selling"), key: "shop_sell_select2" },
+            { label: qsTr("Amount"), key: "shop_sell_number2" },
+            { label: qsTr("Sold"), key: "shop_sold2" }
+        ]
+    },
+    {
+        label: qsTr("Shop Type C"),
+        section: 1,
+        settings: [
+            { label: qsTr("Greeting"), key: "shop_greeting3" },
+            { label: qsTr("Regreeting"), key: "shop_regreeting3" },
+            { label: qsTr("Buy"), key: "shop_buy3" },
+            { label: qsTr("Sell"), key: "shop_sell3" },
+            { label: qsTr("Leave"), key: "shop_leave3" },
+            { label: qsTr("Purchasing"), key: "shop_buy_select3" },
+            { label: qsTr("Amount"), key: "shop_buy_number3" },
+            { label: qsTr("Purchase Done"), key: "shop_purchased3" },
+            { label: qsTr("Selling"), key: "shop_sell_select3" },
+            { label: qsTr("Amount"), key: "shop_sell_number3" },
+            { label: qsTr("Sold"), key: "shop_sold3" }
+        ]
+    },
+    {
+        label: qsTr("Shop Common"),
+        section: 2,
+        settings: [
+            { label: qsTr("Items owned"), key: "possessed_items" },
+            { label: qsTr("Equipped"), key: "equipped_items" }
+        ]
+    },
+    {
+        label: qsTr("Inn Type A"),
+        section: 2,
+        settings: [
+            { label: qsTr("Greeting (Line 1)"), key: "inn_a_greeting_1" },
+            { label: qsTr("Greeting (Line 2)"), key: "inn_a_greeting_3" },
+            { label: qsTr("Stay"), key: "inn_a_accept" },
+            { label: qsTr("Don't Stay"), key: "inn_a_cancel" }
+        ]
+    },
+    {
+        label: qsTr("Inn Type B"),
+        section: 2,
+        settings: [
+            { label: qsTr("Greeting (Line 1)"), key: "inn_b_greeting_1" },
+            { label: qsTr("Greeting (Line 2)"), key: "inn_b_greeting_3" },
+            { label: qsTr("Stay"), key: "inn_b_accept" },
+            { label: qsTr("Don't Stay"), key: "inn_b_cancel" }
+        ]
+    },
+    {
+        label: qsTr("Battle Commands"),
+        section: 3,
+        settings: [
+            { label: qsTr("Fight"), key: "battle_fight" },
+            { label: qsTr("Auto Battle"), key: "battle_auto" },
+            { label: qsTr("Escape"), key: "battle_escape" },
+            { label: qsTr("Attack"), key: "command_attack" },
+            { label: qsTr("Defend"), key: "command_defend" }
+        ]
+    },
+    {
+        label: qsTr("Actor (Battle)"),
+        section: 3,
+        settings: [
+            { label: qsTr("Critical Hit"), key: "actor_critical" },
+            { label: qsTr("Took Damage"), key: "actor_damaged" },
+            { label: qsTr("Took No Damage"), key: "actor_undamaged" },
+            { label: qsTr("Absorbed"), key: "actor_hp_absorbed" },
+            { label: qsTr("Escaped"), key: "escape_success" },
+            { label: qsTr("Escape failed"), key: "escape_failure" },
+            { label: qsTr("Use Item"), key: "use_item" }
+        ]
+    },
+    {
+        label: qsTr("Enemy (Battle)"),
+        section: 3,
+        settings: [
+            { label: qsTr("Critical Hit"), key: "enemy_critical" },
+            { label: qsTr("Took Damage"), key: "enemy_damaged" },
+            { label: qsTr("Took No Damage"), key: "enemy_undamaged" },
+            { label: qsTr("Absorbed"), key: "enemy_hp_absorbed" },
+            { label: qsTr("Escaped"), key: "enemy_escape" },
+            { label: qsTr("Encounter"), key: "encounter" },
+            { label: qsTr("Waiting"), key: "observing" },
+            { label: qsTr("Charging"), key: "focus" },
+            { label: qsTr("Self Destruct"), key: "autodestruction" },
+            { label: qsTr("Transform"), key: "enemy_transform" }
+        ]
+    },
+    {
+        label: qsTr("Shared (Battle)"),
+        section: 3,
+        settings: [
+            { label: qsTr("Basic Attack"), key: "attacking" },
+            { label: qsTr("Defending"), key: "defending" },
+            { label: qsTr("Skill A failed"), key: "skill_failure_a" },
+            { label: qsTr("Skill B failed"), key: "skill_failure_b" },
+            { label: qsTr("Skill C failed"), key: "skill_failure_c" },
+            { label: qsTr("Dodged"), key: "dodge" },
+            { label: qsTr("HP/MP Recovery"), key: "hp_recovery" },
+            { label: qsTr("Attribute up"), key: "parameter_increase" },
+            { label: qsTr("Attribute down"), key: "parameter_decrease" },
+            { label: qsTr("Resistance up"), key: "resistance_increase" },
+            { label: qsTr("Resistance down"), key: "resistance_decrease" }
+        ]
+    },
+    {
+        label: qsTr("Battle State"),
+        section: 3,
+        settings: [
+            { label: qsTr("Battle Start"), key: "battle_start" },
+            { label: qsTr("Miss"), key: "miss" },
+            { label: qsTr("Preemptive"), key: "special_combat" },
+            { label: qsTr("Victory"), key: "victory" },
+            { label: qsTr("Defeat"), key: "defeat" },
+            { label: qsTr("Receive Exp"), key: "exp_received" },
+            { label: qsTr("Receive Gold"), key: "gold_recieved_a" },
+            { label: qsTr("Receive Item"), key: "item_recieved" }
+        ]
+    }
+    ]
 
-    // Just for demonstration
-    // The finished Ui should not be auto-generated :)
+    actions: [
+    ]
 
-    Ez.FormLayout {
-        anchors.fill: parent
+    ColumnLayout {
+        spacing: Kirigami.Units.largeSpacing
 
         Repeater {
-            model: root.jsonKeys
+            model: root.categoryModel
+            delegate: ColumnLayout {
+                Layout.maximumWidth: Kirigami.Units.gridUnit * 48
+                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
 
-            delegate: Ez.TextField {
-                jsonData: root.jsonData
+                Kirigami.Heading {
+                    Layout.alignment: Qt.AlignVCenter
 
-                key: modelData
-                Kirigami.FormData.label: modelData
+                    level: 2
+                    type: Kirigami.Heading.Primary
+                    text: modelData.label
+                    elide: Text.ElideRight
+                }
+
+                Kirigami.Separator {
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                GridLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    columns: Math.max(1, Math.min(Math.floor(root.width / (Kirigami.Units.gridUnit * 16)), 3))
+                    Layout.fillWidth: true
+
+                    Repeater {
+                        model: modelData.settings
+                        delegate: ColumnLayout {
+                            Controls.Label { text: modelData.label }
+                            Ez.TextField { jsonData: root.jsonData; key: modelData.key; Layout.fillWidth: true }
+                        }
+                    }
+                }
             }
         }
-    }
-
-    Component.onCompleted: {
-        let rawString = root.jsonData.toJson("")
-        console.log(rawString)
-
-        let parsedObj = JSON.parse(rawString)
-        root.jsonKeys = Object.keys(parsedObj)
     }
 }

--- a/src/ui/picker/PickerBase.qml
+++ b/src/ui/picker/PickerBase.qml
@@ -80,14 +80,14 @@ Kirigami.Page {
             }
         }
 
-        Kirigami.FormLayout {
+        Ez.FormLayout {
             id: formLayout
             Layout.alignment: Qt.AlignTop
 
             Controls.TextField {
                 id: nameInput
                 text: root.pickerData.filename
-                Kirigami.FormData.label: "Name:"
+                Kirigami.FormData.label: "Name"
                 visible: false
             }
         }


### PR DESCRIPTION
Was discussing with jetrotal a while ago how to make the editor more "responsive" without making it look like a mobile app.

What we came up with is using a Grid Lane Layout which automatically moves Tiles (I call it Card to match Kirigami) around based on the window width. So it shows more tiles per line depending on the Window/Screen Width.

The Grid Lane Layout (or Masonry Layout) itself was mostly AI generated (I added the doc comments) and I couldn't find any prior work regarding this in QML. At least it looks like it works and is only about 80 lines.

Also had to vendor the FormLayout as it hardcodes some width and padding which is inconvenient for us as this stuff was too small (and felt mobile first). As an alternative I can provide AI-generated monkey-patching of the original FormLayout but the code was so bad that I consider vendoring the cleaner way here...

https://github.com/user-attachments/assets/79af3756-d5a4-4c66-a2df-7c6939542705


For the lulz: This happens when you tell Spectacle to record a Window and then resize it while recording xD

https://github.com/user-attachments/assets/fba7a4b0-b26c-4302-bbca-573ee44242e2

